### PR TITLE
Update and add missing Best of JS projects, fix some names

### DIFF
--- a/surveys/2018/website/src/data/bestofjs.json
+++ b/surveys/2018/website/src/data/bestofjs.json
@@ -1,6 +1,6 @@
 {
-    "count": 108,
-    "updated_at": "2018-10-10T21:22:03.754Z",
+    "count": 123,
+    "updated_at": "2018-11-17T05:13:42.081Z",
     "projects": [
         {
             "name": "TypeScript",
@@ -8,7 +8,7 @@
             "homepage": "http://www.typescriptlang.org",
             "slug": "typescript",
             "github": "Microsoft/TypeScript",
-            "stars": 39898
+            "stars": 41328
         },
         {
             "name": "Flow",
@@ -16,7 +16,7 @@
             "homepage": "https://flow.org/",
             "slug": "flow",
             "github": "facebook/flow",
-            "stars": 18002
+            "stars": 18289
         },
         {
             "name": "Elm",
@@ -24,7 +24,7 @@
             "homepage": "http://elm-lang.org/",
             "slug": "elm",
             "github": "elm/compiler",
-            "stars": 4781
+            "stars": 4862
         },
         {
             "name": "ClojureScript",
@@ -32,7 +32,7 @@
             "homepage": "http://clojurescript.org/",
             "slug": "clojurescript",
             "github": "clojure/clojurescript",
-            "stars": 7845
+            "stars": 7883
         },
         {
             "name": "Reason",
@@ -40,7 +40,23 @@
             "homepage": "http://reasonml.github.io",
             "slug": "reason",
             "github": "facebook/reason",
-            "stars": 6483
+            "stars": 6690
+        },
+        {
+            "name": "PureScript",
+            "description": "A strongly-typed language that compiles to Javascript",
+            "homepage": "http://purescript.org",
+            "slug": "purescript",
+            "github": "purescript/purescript",
+            "stars": 5298
+        },
+        {
+            "name": "CoffeeScript",
+            "description": "Unfancy JavaScript",
+            "homepage": "http://coffeescript.org/",
+            "slug": "coffeescript",
+            "github": "jashkenas/coffeescript",
+            "stars": 14965
         },
         {
             "name": "React",
@@ -48,7 +64,7 @@
             "homepage": "https://reactjs.org",
             "slug": "react",
             "github": "facebook/react",
-            "stars": 112845
+            "stars": 115640
         },
         {
             "name": "Angular 1",
@@ -56,7 +72,7 @@
             "homepage": "https://angularjs.org",
             "slug": "angular-1",
             "github": "angular/angular.js",
-            "stars": 59147
+            "stars": 59259
         },
         {
             "name": "Ember",
@@ -64,7 +80,7 @@
             "homepage": "http://www.emberjs.com",
             "slug": "ember",
             "github": "emberjs/ember.js",
-            "stars": 20086
+            "stars": 20183
         },
         {
             "name": "Vue.js",
@@ -72,7 +88,7 @@
             "homepage": "http://vuejs.org",
             "slug": "vuejs",
             "github": "vuejs/vue",
-            "stars": 116067
+            "stars": 119188
         },
         {
             "name": "Backbone",
@@ -80,15 +96,15 @@
             "homepage": "http://backbonejs.org",
             "slug": "backbone",
             "github": "jashkenas/backbone",
-            "stars": 27312
+            "stars": 27331
         },
         {
             "name": "Polymer",
-            "description": "Build modern apps using web components",
+            "description": "Our original Web Component library.",
             "homepage": "https://www.polymer-project.org/",
             "slug": "polymer",
             "github": "Polymer/polymer",
-            "stars": 20270
+            "stars": 20414
         },
         {
             "name": "Aurelia",
@@ -96,7 +112,7 @@
             "homepage": "http://aurelia.io/",
             "slug": "aurelia",
             "github": "aurelia/framework",
-            "stars": 10638
+            "stars": 10677
         },
         {
             "name": "Preact",
@@ -104,7 +120,7 @@
             "homepage": "https://preactjs.com",
             "slug": "preact",
             "github": "developit/preact",
-            "stars": 20318
+            "stars": 20684
         },
         {
             "name": "Knockout",
@@ -112,7 +128,7 @@
             "homepage": "http://knockoutjs.com/",
             "slug": "knockout",
             "github": "knockout/knockout",
-            "stars": 9152
+            "stars": 9204
         },
         {
             "name": "jQuery",
@@ -120,7 +136,7 @@
             "homepage": "https://jquery.com/",
             "slug": "jquery",
             "github": "jquery/jquery",
-            "stars": 50115
+            "stars": 50348
         },
         {
             "name": "Cycle.js",
@@ -128,7 +144,7 @@
             "homepage": "http://cycle.js.org",
             "slug": "cyclejs",
             "github": "cyclejs/cyclejs",
-            "stars": 8730
+            "stars": 8808
         },
         {
             "name": "Mithril",
@@ -136,15 +152,15 @@
             "homepage": "http://mithril.js.org",
             "slug": "mithril",
             "github": "MithrilJS/mithril.js",
-            "stars": 9657
+            "stars": 10077
         },
         {
             "name": "Inferno",
-            "description": "An extremely fast, React-like JavaScript library for building modern user interfaces",
+            "description": ":fire: An extremely fast, React-like JavaScript library for building modern user interfaces",
             "homepage": "http://infernojs.org",
             "slug": "inferno",
             "github": "infernojs/inferno",
-            "stars": 13033
+            "stars": 13217
         },
         {
             "name": "Svelte",
@@ -152,14 +168,14 @@
             "homepage": "https://svelte.technology",
             "slug": "svelte",
             "github": "sveltejs/svelte",
-            "stars": 8123
+            "stars": 8380
         },
         {
             "name": "Hyperapp",
             "description": "1 kB JavaScript micro-framework for building declarative web applications",
             "slug": "hyperapp",
             "github": "jorgebucaran/hyperapp",
-            "stars": 15464
+            "stars": 15717
         },
         {
             "name": "Choo",
@@ -167,7 +183,7 @@
             "homepage": "https://choo.io/",
             "slug": "choo",
             "github": "choojs/choo",
-            "stars": 5702
+            "stars": 5771
         },
         {
             "name": "Marionette",
@@ -175,7 +191,7 @@
             "homepage": "http://marionettejs.com",
             "slug": "marionette",
             "github": "marionettejs/backbone.marionette",
-            "stars": 7170
+            "stars": 7163
         },
         {
             "name": "Marko",
@@ -183,7 +199,7 @@
             "homepage": "https://markojs.com/",
             "slug": "marko",
             "github": "marko-js/marko",
-            "stars": 7331
+            "stars": 7622
         },
         {
             "name": "Riot",
@@ -191,7 +207,47 @@
             "homepage": "https://riot.js.org",
             "slug": "riotjs",
             "github": "riot/riot",
-            "stars": 13260
+            "stars": 13328
+        },
+        {
+            "name": "Dojo",
+            "description": ":rocket: Dojo 2 - language helpers and utilities.",
+            "homepage": "http://dojo.io",
+            "slug": "dojo",
+            "github": "dojo/core",
+            "stars": 224
+        },
+        {
+            "name": "CanJS",
+            "description": "JS framework providing state management, templates & custom elements. Helps you build the impossible while keeping the common stuff easy.",
+            "homepage": "https://canjs.com/",
+            "slug": "canjs",
+            "github": "canjs/canjs",
+            "stars": 1699
+        },
+        {
+            "name": "Glimmer.js",
+            "description": "A fast and lightweight UI component library from the Ember.js team",
+            "homepage": "https://glimmerjs.com",
+            "slug": "glimmerjs",
+            "github": "glimmerjs/glimmer.js",
+            "stars": 412
+        },
+        {
+            "name": "Web Components",
+            "description": "A suite of polyfills supporting the HTML Web Components specs",
+            "homepage": "http://webcomponents.org/polyfills/",
+            "slug": "web-components",
+            "github": "webcomponents/webcomponentsjs",
+            "stars": 3198
+        },
+        {
+            "name": "Reagent",
+            "description": "A minimalistic ClojureScript interface to React.js",
+            "homepage": "http://reagent-project.github.io/",
+            "slug": "reagent",
+            "github": "reagent-project/reagent",
+            "stars": 3212
         },
         {
             "name": "Meteor",
@@ -199,7 +255,7 @@
             "homepage": "https://www.meteor.com",
             "slug": "meteor",
             "github": "meteor/meteor",
-            "stars": 40363
+            "stars": 40489
         },
         {
             "name": "Express",
@@ -207,7 +263,7 @@
             "homepage": "https://expressjs.com",
             "slug": "express",
             "github": "expressjs/express",
-            "stars": 40508
+            "stars": 41055
         },
         {
             "name": "Koa",
@@ -215,7 +271,7 @@
             "homepage": "https://koajs.com",
             "slug": "koa",
             "github": "koajs/koa",
-            "stars": 23418
+            "stars": 23896
         },
         {
             "name": "Hapi",
@@ -223,7 +279,7 @@
             "homepage": "hapijs.com",
             "slug": "hapi",
             "github": "hapijs/hapi",
-            "stars": 10204
+            "stars": 10372
         },
         {
             "name": "FeathersJS",
@@ -231,7 +287,7 @@
             "homepage": "https://feathersjs.com",
             "slug": "feathers",
             "github": "feathersjs/feathers",
-            "stars": 9819
+            "stars": 10001
         },
         {
             "name": "Sails",
@@ -239,7 +295,7 @@
             "homepage": "https://sailsjs.com",
             "slug": "sails",
             "github": "balderdashy/sails",
-            "stars": 19723
+            "stars": 19872
         },
         {
             "name": "Loopback",
@@ -247,7 +303,7 @@
             "homepage": "http://loopback.io",
             "slug": "loopback",
             "github": "strongloop/loopback",
-            "stars": 11748
+            "stars": 11970
         },
         {
             "name": "Keystone",
@@ -255,7 +311,7 @@
             "homepage": "http://www.keystonejs.com",
             "slug": "keystone",
             "github": "keystonejs/keystone",
-            "stars": 13438
+            "stars": 13617
         },
         {
             "name": "Node.js",
@@ -263,7 +319,7 @@
             "homepage": "https://nodejs.org",
             "slug": "nodejs",
             "github": "nodejs/node",
-            "stars": 54199
+            "stars": 55447
         },
         {
             "name": "Restify",
@@ -271,15 +327,15 @@
             "homepage": "http://restify.com",
             "slug": "restify",
             "github": "restify/node-restify",
-            "stars": 8678
+            "stars": 8788
         },
         {
             "name": "Adonis",
             "description": "NodeJs Web Application Framework. Makes it easy for you to write webapps with less code :smiley:",
-            "homepage": "http://adonisjs.com",
+            "homepage": "https://adonisjs.com",
             "slug": "adonis",
             "github": "adonisjs/adonis-framework",
-            "stars": 4857
+            "stars": 5047
         },
         {
             "name": "Next.js",
@@ -287,7 +343,7 @@
             "homepage": "https://nextjs.org",
             "slug": "nextjs",
             "github": "zeit/next.js",
-            "stars": 30182
+            "stars": 31515
         },
         {
             "name": "Serverless",
@@ -295,7 +351,7 @@
             "homepage": "https://serverless.com",
             "slug": "serverless",
             "github": "serverless/serverless",
-            "stars": 25823
+            "stars": 26520
         },
         {
             "name": "Socket.io",
@@ -303,7 +359,7 @@
             "homepage": "http://socket.io",
             "slug": "socketio",
             "github": "socketio/socket.io",
-            "stars": 43823
+            "stars": 44264
         },
         {
             "name": "Micro",
@@ -311,7 +367,7 @@
             "homepage": "https://zeit.co/blog/micro-8",
             "slug": "micro",
             "github": "zeit/micro",
-            "stars": 7394
+            "stars": 7623
         },
         {
             "name": "Kraken",
@@ -319,7 +375,7 @@
             "homepage": "http://krakenjs.com",
             "slug": "kraken",
             "github": "krakenjs/kraken-js",
-            "stars": 4667
+            "stars": 4688
         },
         {
             "name": "Redux",
@@ -327,7 +383,7 @@
             "homepage": "http://redux.js.org",
             "slug": "redux",
             "github": "reduxjs/redux",
-            "stars": 44465
+            "stars": 45150
         },
         {
             "name": "MobX",
@@ -335,7 +391,7 @@
             "homepage": "http://mobx.js.org",
             "slug": "mobx",
             "github": "mobxjs/mobx",
-            "stars": 17045
+            "stars": 17502
         },
         {
             "name": "GraphQL",
@@ -343,7 +399,7 @@
             "homepage": "https://graphql.org/",
             "slug": "graphql",
             "github": "facebook/graphql",
-            "stars": 9746
+            "stars": 10127
         },
         {
             "name": "Relay/Relay Modern",
@@ -351,7 +407,7 @@
             "homepage": "https://facebook.github.io/relay/",
             "slug": "relay",
             "github": "facebook/relay",
-            "stars": 11515
+            "stars": 11678
         },
         {
             "name": "Falcor",
@@ -359,7 +415,7 @@
             "homepage": "http://netflix.github.io/falcor",
             "slug": "falcor",
             "github": "Netflix/falcor",
-            "stars": 8996
+            "stars": 9047
         },
         {
             "name": "Apollo",
@@ -367,7 +423,7 @@
             "homepage": "https://www.apollographql.com/client/",
             "slug": "apollo-client",
             "github": "apollographql/apollo-client",
-            "stars": 8761
+            "stars": 9132
         },
         {
             "name": "VueX",
@@ -375,7 +431,7 @@
             "homepage": "https://vuex.vuejs.org",
             "slug": "vuex",
             "github": "vuejs/vuex",
-            "stars": 17198
+            "stars": 17727
         },
         {
             "name": "Flux",
@@ -383,7 +439,7 @@
             "homepage": "http://facebook.github.io/flux/",
             "slug": "flux",
             "github": "facebook/flux",
-            "stars": 15627
+            "stars": 15729
         },
         {
             "name": "PouchDB",
@@ -391,7 +447,7 @@
             "homepage": "https://pouchdb.com/",
             "slug": "pouchdb",
             "github": "pouchdb/pouchdb",
-            "stars": 11128
+            "stars": 11278
         },
         {
             "name": "RxJS",
@@ -399,7 +455,7 @@
             "homepage": "http://reactivex.io",
             "slug": "rxjs",
             "github": "Reactive-Extensions/RxJS",
-            "stars": 19393
+            "stars": 19444
         },
         {
             "name": "Realm",
@@ -407,7 +463,7 @@
             "homepage": "https://realm.io",
             "slug": "realm",
             "github": "realm/realm-js",
-            "stars": 3145
+            "stars": 3210
         },
         {
             "name": "Gun.js",
@@ -415,7 +471,7 @@
             "homepage": "https://gun.eco/docs",
             "slug": "gun",
             "github": "amark/gun",
-            "stars": 8939
+            "stars": 9091
         },
         {
             "name": "Cerebral",
@@ -423,7 +479,30 @@
             "homepage": "http://cerebraljs.com",
             "slug": "cerebral",
             "github": "cerebral/cerebral",
-            "stars": 1641
+            "stars": 1667
+        },
+        {
+            "name": "ember-data",
+            "description": "A data persistence library for Ember.js.",
+            "slug": "ember-data",
+            "github": "emberjs/data",
+            "stars": 2897
+        },
+        {
+            "name": "NgRx",
+            "description": "Reactive libraries for Angular",
+            "homepage": "https://ngrx.io",
+            "slug": "ngrx",
+            "github": "ngrx/platform",
+            "stars": 3958
+        },
+        {
+            "name": "MongoDB",
+            "description": "Mongo DB Native NodeJS Driver",
+            "homepage": "http://mongodb.github.com/node-mongodb-native/",
+            "slug": "mongodb",
+            "github": "mongodb/node-mongodb-native",
+            "stars": 7441
         },
         {
             "name": "Mocha",
@@ -431,7 +510,7 @@
             "homepage": "https://mochajs.org",
             "slug": "mocha",
             "github": "mochajs/mocha",
-            "stars": 16381
+            "stars": 16626
         },
         {
             "name": "Jasmine",
@@ -439,7 +518,7 @@
             "homepage": "http://jasmine.github.io/",
             "slug": "jasmine",
             "github": "jasmine/jasmine",
-            "stars": 13901
+            "stars": 13979
         },
         {
             "name": "Enzyme",
@@ -447,7 +526,7 @@
             "homepage": "https://airbnb.io/enzyme/",
             "slug": "enzyme",
             "github": "airbnb/enzyme",
-            "stars": 15410
+            "stars": 15776
         },
         {
             "name": "Jest",
@@ -455,21 +534,21 @@
             "homepage": "https://facebook.github.io/jest/",
             "slug": "jest",
             "github": "facebook/jest",
-            "stars": 20895
+            "stars": 21645
         },
         {
             "name": "Tape",
             "description": "tap-producing test harness for node and browsers",
             "slug": "tape",
             "github": "substack/tape",
-            "stars": 4768
+            "stars": 4807
         },
         {
             "name": "Ava",
             "description": "🚀 Futuristic JavaScript test runner",
             "slug": "ava",
             "github": "avajs/ava",
-            "stars": 14845
+            "stars": 15083
         },
         {
             "name": "Karma",
@@ -477,7 +556,7 @@
             "homepage": "http://karma-runner.github.io",
             "slug": "karma",
             "github": "karma-runner/karma",
-            "stars": 10225
+            "stars": 10303
         },
         {
             "name": "Chai",
@@ -485,7 +564,7 @@
             "homepage": "http://chaijs.com",
             "slug": "chai",
             "github": "chaijs/chai",
-            "stars": 5754
+            "stars": 5851
         },
         {
             "name": "Nightwatch",
@@ -493,7 +572,7 @@
             "homepage": "http://nightwatchjs.org",
             "slug": "nightwatch",
             "github": "nightwatchjs/nightwatch",
-            "stars": 8632
+            "stars": 8721
         },
         {
             "name": "Tap",
@@ -501,15 +580,15 @@
             "homepage": "https://www.node-tap.org/",
             "slug": "node-tap",
             "github": "tapjs/node-tap",
-            "stars": 1268
+            "stars": 1276
         },
         {
-            "name": "Cypress",
+            "name": "cypress",
             "description": "Fast, easy and reliable testing for anything that runs in a browser.",
             "homepage": "https://www.cypress.io",
             "slug": "cypress",
             "github": "cypress-io/cypress",
-            "stars": 8055
+            "stars": 8666
         },
         {
             "name": "intern",
@@ -517,7 +596,7 @@
             "homepage": "https://theintern.io/",
             "slug": "intern",
             "github": "theintern/intern",
-            "stars": 4051
+            "stars": 4065
         },
         {
             "name": "PhantomJS",
@@ -525,7 +604,7 @@
             "homepage": "http://phantomjs.org",
             "slug": "phantomjs",
             "github": "ariya/phantomjs",
-            "stars": 26056
+            "stars": 26201
         },
         {
             "name": "Nightmare",
@@ -533,7 +612,7 @@
             "homepage": "https://open.segment.com",
             "slug": "nightmare",
             "github": "segmentio/nightmare",
-            "stars": 16240
+            "stars": 16458
         },
         {
             "name": "Sinon",
@@ -541,7 +620,7 @@
             "homepage": "https://sinonjs.org/",
             "slug": "sinonjs",
             "github": "sinonjs/sinon",
-            "stars": 6452
+            "stars": 6597
         },
         {
             "name": "TestCafe",
@@ -549,7 +628,7 @@
             "homepage": "https://devexpress.github.io/testcafe/",
             "slug": "testcafe",
             "github": "DevExpress/testcafe",
-            "stars": 5496
+            "stars": 5705
         },
         {
             "name": "QUnit",
@@ -557,7 +636,7 @@
             "homepage": "https://qunitjs.com",
             "slug": "qunit",
             "github": "qunitjs/qunit",
-            "stars": 3787
+            "stars": 3794
         },
         {
             "name": "Protractor",
@@ -565,14 +644,22 @@
             "homepage": "http://www.protractortest.org",
             "slug": "protractor",
             "github": "angular/protractor",
-            "stars": 7826
+            "stars": 7895
+        },
+        {
+            "name": "Cucumber.js",
+            "description": "Cucumber for JavaScript",
+            "homepage": "https://cucumber.io/",
+            "slug": "cucumberjs",
+            "github": "cucumber/cucumber-js",
+            "stars": 3322
         },
         {
             "name": "SASS/SCSS",
             "description": ":rainbow: Node.js bindings to libsass",
             "slug": "sass",
             "github": "sass/node-sass",
-            "stars": 5567
+            "stars": 5692
         },
         {
             "name": "Stylus",
@@ -580,7 +667,7 @@
             "homepage": "http://stylus-lang.com/",
             "slug": "stylus",
             "github": "stylus/stylus",
-            "stars": 9479
+            "stars": 9560
         },
         {
             "name": "LESS",
@@ -588,7 +675,7 @@
             "homepage": "http://lesscss.org",
             "slug": "less",
             "github": "less/less.js",
-            "stars": 15763
+            "stars": 15829
         },
         {
             "name": "Bootstrap",
@@ -596,7 +683,7 @@
             "homepage": "http://getbootstrap.com",
             "slug": "bootstrap",
             "github": "twbs/bootstrap",
-            "stars": 127882
+            "stars": 128736
         },
         {
             "name": "Foundation",
@@ -604,7 +691,7 @@
             "homepage": "http://foundation.zurb.com",
             "slug": "foundation",
             "github": "zurb/foundation-sites",
-            "stars": 27674
+            "stars": 27796
         },
         {
             "name": "PostCSS",
@@ -612,7 +699,7 @@
             "homepage": "https://postcss.org/",
             "slug": "postcss",
             "github": "postcss/postcss",
-            "stars": 19463
+            "stars": 19664
         },
         {
             "name": "Bulma",
@@ -620,7 +707,7 @@
             "homepage": "https://bulma.io",
             "slug": "bulma",
             "github": "jgthms/bulma",
-            "stars": 30347
+            "stars": 31172
         },
         {
             "name": "Semantic UI",
@@ -628,7 +715,7 @@
             "homepage": "http://www.semantic-ui.com",
             "slug": "semanticui",
             "github": "Semantic-Org/Semantic-UI",
-            "stars": 43104
+            "stars": 43479
         },
         {
             "name": "Materialize",
@@ -636,14 +723,14 @@
             "homepage": "https://materializecss.com",
             "slug": "materialize-css",
             "github": "Dogfalo/materialize",
-            "stars": 34121
+            "stars": 34408
         },
         {
             "name": "CSS modules",
             "description": "Documentation about css-modules",
             "slug": "css-modules",
             "github": "css-modules/css-modules",
-            "stars": 10690
+            "stars": 10914
         },
         {
             "name": "Material Design",
@@ -651,7 +738,7 @@
             "homepage": "https://getmdl.io",
             "slug": "material-design-lite",
             "github": "google/material-design-lite",
-            "stars": 30684
+            "stars": 30779
         },
         {
             "name": "PureCSS",
@@ -659,7 +746,7 @@
             "homepage": "http://purecss.io/",
             "slug": "purecss",
             "github": "pure-css/pure",
-            "stars": 19147
+            "stars": 19295
         },
         {
             "name": "Material UI",
@@ -667,7 +754,7 @@
             "homepage": "https://material-ui.com/",
             "slug": "material-ui",
             "github": "mui-org/material-ui",
-            "stars": 41000
+            "stars": 42003
         },
         {
             "name": "UIKit",
@@ -675,7 +762,7 @@
             "homepage": "http://getuikit.com",
             "slug": "uikit",
             "github": "uikit/uikit",
-            "stars": 13240
+            "stars": 13439
         },
         {
             "name": "Tachyons",
@@ -683,7 +770,7 @@
             "homepage": "https://tachyons.io",
             "slug": "tachyons",
             "github": "tachyons-css/tachyons",
-            "stars": 7817
+            "stars": 8047
         },
         {
             "name": "Skeleton",
@@ -691,7 +778,7 @@
             "homepage": "http://www.getskeleton.com",
             "slug": "skeleton",
             "github": "dhg/Skeleton",
-            "stars": 16073
+            "stars": 16203
         },
         {
             "name": "styled-components",
@@ -699,7 +786,7 @@
             "homepage": "https://styled-components.com",
             "slug": "styled-components",
             "github": "styled-components/styled-components",
-            "stars": 19512
+            "stars": 20322
         },
         {
             "name": "CSSnext",
@@ -707,7 +794,7 @@
             "homepage": "https://moox.io/blog/deprecating-cssnext/",
             "slug": "cssnext",
             "github": "MoOx/postcss-cssnext",
-            "stars": 5380
+            "stars": 5392
         },
         {
             "name": "Webpack",
@@ -715,7 +802,7 @@
             "homepage": "https://webpack.js.org",
             "slug": "webpack",
             "github": "webpack/webpack",
-            "stars": 44487
+            "stars": 45213
         },
         {
             "name": "Grunt",
@@ -723,7 +810,7 @@
             "homepage": "http://gruntjs.com/",
             "slug": "grunt",
             "github": "gruntjs/grunt",
-            "stars": 11869
+            "stars": 11879
         },
         {
             "name": "Gulp",
@@ -731,7 +818,7 @@
             "homepage": "http://gulpjs.com",
             "slug": "gulp",
             "github": "gulpjs/gulp",
-            "stars": 30419
+            "stars": 30567
         },
         {
             "name": "Browserify",
@@ -739,7 +826,7 @@
             "homepage": "http://browserify.org/",
             "slug": "browserify",
             "github": "browserify/browserify",
-            "stars": 12257
+            "stars": 12312
         },
         {
             "name": "NPM",
@@ -747,7 +834,7 @@
             "homepage": "http://npm.community/",
             "slug": "npm",
             "github": "npm/npm",
-            "stars": 17011
+            "stars": 17052
         },
         {
             "name": "Rollup",
@@ -755,7 +842,7 @@
             "homepage": "https://rollupjs.org",
             "slug": "rollup",
             "github": "rollup/rollup",
-            "stars": 13817
+            "stars": 14109
         },
         {
             "name": "Brunch",
@@ -763,14 +850,14 @@
             "homepage": "http://brunch.io",
             "slug": "brunch",
             "github": "brunch/brunch",
-            "stars": 6526
+            "stars": 6533
         },
         {
             "name": "Broccoli",
             "description": "Browser compilation library – an asset pipeline for applications that run in the browser",
             "slug": "broccoli",
             "github": "broccolijs/broccoli",
-            "stars": 3141
+            "stars": 3151
         },
         {
             "name": "Jspm",
@@ -778,7 +865,7 @@
             "homepage": "https://jspm.org",
             "slug": "jspm",
             "github": "jspm/jspm-cli",
-            "stars": 3665
+            "stars": 3667
         },
         {
             "name": "Fusebox",
@@ -786,14 +873,14 @@
             "homepage": "http://fuse-box.org",
             "slug": "fusebox",
             "github": "fuse-box/fuse-box",
-            "stars": 3495
+            "stars": 3557
         },
         {
             "name": "SystemJS",
             "description": "Dynamic ES module loader",
             "slug": "systemjs",
             "github": "systemjs/systemjs",
-            "stars": 9264
+            "stars": 9337
         },
         {
             "name": "StealJS",
@@ -801,7 +888,7 @@
             "homepage": "https://stealjs.com",
             "slug": "steal",
             "github": "stealjs/steal",
-            "stars": 1293
+            "stars": 1299
         },
         {
             "name": "Babel",
@@ -809,7 +896,7 @@
             "homepage": "https://babeljs.io/",
             "slug": "babel",
             "github": "babel/babel",
-            "stars": 29978
+            "stars": 30520
         },
         {
             "name": "React Native",
@@ -817,7 +904,7 @@
             "homepage": "https://facebook.github.io/react-native/",
             "slug": "react-native",
             "github": "facebook/react-native",
-            "stars": 69602
+            "stars": 70985
         },
         {
             "name": "Ionic",
@@ -825,7 +912,7 @@
             "homepage": "https://ionicframework.com/",
             "slug": "ionic",
             "github": "ionic-team/ionic",
-            "stars": 35526
+            "stars": 35827
         },
         {
             "name": "NativeScript",
@@ -833,15 +920,47 @@
             "homepage": "https://www.nativescript.org",
             "slug": "nativescript",
             "github": "NativeScript/NativeScript",
-            "stars": 15040
+            "stars": 15433
         },
         {
             "name": "Electron",
-            "description": "Build cross-platform desktop apps with JavaScript, HTML, and CSS",
+            "description": ":electron: Build cross-platform desktop apps with JavaScript, HTML, and CSS",
             "homepage": "https://electronjs.org",
             "slug": "electron",
             "github": "electron/electron",
-            "stars": 65386
+            "stars": 66637
+        },
+        {
+            "name": "Weex",
+            "description": "Apache Weex (Incubating)",
+            "homepage": "https://weex.apache.org",
+            "slug": "weex",
+            "github": "apache/incubator-weex",
+            "stars": 11085
+        },
+        {
+            "name": "NW.js",
+            "description": "Call all Node.js modules directly from DOM/WebWorker and enable a new way of writing applications with all Web technologies.",
+            "homepage": "https://nwjs.io",
+            "slug": "nwjs",
+            "github": "nwjs/nw.js",
+            "stars": 34561
+        },
+        {
+            "name": "Quasar",
+            "description": "Quasar Framework",
+            "homepage": "https://quasar-framework.org",
+            "slug": "quasar",
+            "github": "quasarframework/quasar",
+            "stars": 7792
+        },
+        {
+            "name": "Expo",
+            "description": "The Expo platform for making cross-platform mobile apps",
+            "homepage": "https://docs.expo.io/",
+            "slug": "expo",
+            "github": "expo/expo",
+            "stars": 4508
         },
         {
             "name": "Yarn",
@@ -849,7 +968,7 @@
             "homepage": "https://yarnpkg.com",
             "slug": "yarn",
             "github": "yarnpkg/yarn",
-            "stars": 33386
+            "stars": 33750
         },
         {
             "name": "NPM",
@@ -857,7 +976,7 @@
             "homepage": "http://npm.community/",
             "slug": "npm",
             "github": "npm/npm",
-            "stars": 17011
+            "stars": 17052
         }
     ]
 }

--- a/surveys/2018/website/src/data/results/sections/front-end-frameworks.yml
+++ b/surveys/2018/website/src/data/results/sections/front-end-frameworks.yml
@@ -328,7 +328,7 @@ other_tools:
         name: cyclejs
         count: 57
     -
-        name: Knockout
+        name: knockout
         count: 50
     -
         name: riotjs
@@ -358,7 +358,7 @@ other_tools:
         name: extjs
         count: 15
     -
-        name: glimmer
+        name: glimmerjs
         count: 15
     -
         name: purescript

--- a/surveys/2018/website/src/data/results/sections/testing.yml
+++ b/surveys/2018/website/src/data/results/sections/testing.yml
@@ -354,13 +354,13 @@ other_tools:
         name: nightwatch
         count: 33
     -
-        name: sinon
+        name: sinonjs
         count: 31
     -
         name: cucumberjs
         count: 30
     -
-        name: tap
+        name: node-tap
         count: 22
     -
         name: intern


### PR DESCRIPTION
## Goals 

* Update the JSON file used to display data about projects tracked in _Best of JavaScript_.
* Fix some incorrect names, to match slugs used in _Best of JavaScript_.

## Details

123 projects are included in the JSON file.

Added links (15):

* purescript
* coffeescript
* dojo
* canjs
* glimmerjs
* web-components
* reagent
* ember-data
* ngrx
* mongodb
* cucumberjs
* weex
* nwjs
* quasar
* expo

Fixed names:

* tap => node-tap
* sinon => sinonjs
* Knockout => knockout
* glimmer => glimmerjs
