### PR TITLE
Enable language selector

### DIFF
--- a/surveys/2018/config/locales.yml
+++ b/surveys/2018/config/locales.yml
@@ -5,3 +5,7 @@
 - locale: fr-FR
   path:   fr
   label:  🇫🇷 français
+
+- locale: hu-HU
+  path:   hu
+  label:  HU magyar

--- a/surveys/2018/website/src/core/Layout.js
+++ b/surveys/2018/website/src/core/Layout.js
@@ -10,7 +10,7 @@ import { PageContextProvider } from './pages/pageContext'
 import { mergePageContext } from './pages/pageHelpers'
 import { I18nContextProvider } from './i18n/i18nContext'
 import PageMetaDebug from './pages/PageMetaDebug'
-// import LangSelector from './i18n/LangSelector'
+import LangSelector from './i18n/LangSelector'
 
 export default class Layout extends PureComponent {
     static propTypes = {
@@ -101,10 +101,8 @@ export default class Layout extends PureComponent {
                                 )}
                             </div>
                         </div>
-                        {/*
                         Disabled until we validate en-US is working as expected
                         <LangSelector />
-                        */}
                     </div>
                 </I18nContextProvider>
             </PageContextProvider>

--- a/surveys/2018/website/src/translations/hu-HU.yml
+++ b/surveys/2018/website/src/translations/hu-HU.yml
@@ -1,0 +1,752 @@
+locale: hu-HU
+translations:
+    # general
+    - key: share
+      t: Share
+    - key: average
+      t: Average  
+    - key: conclusion  
+      t: Conclusion
+    - key: tools_salary_range_average
+      t: Average salary
+    - key: tools_company_size_average
+      t: Average company size
+    - key: tools_years_of_experience_average
+      t: Average years of experience
+    - key: users_percentage
+      t: percentage of users
+    - key: salary_range_axis_legend
+      t: salary range
+    - key: years_of_experience_axis_legend
+      t: years of experience
+    - key: company_size_axis_legend
+      t: number of employees
+    - key: percents_display_mode
+      t: Percents
+    - key: counts_display_mode
+      t: Counts
+    - key: awards_runner_ups
+      t: Runner-Ups
+    - key: tool_homepage
+      t: Homepage
+    - key: from_to_short
+      t: ${from} to ${to}
+    - key: users_count
+      t: ${count} users
+    - key: percentage_of_respondents
+      t: ${percentage} of respondents
+    - key: partners.premium_partners
+      t: Our 2018 Premium Partners
+    - key: partners.become_partner
+      t: Become a partner
+    - key: partners.thanks
+      t: |
+        Thanks to our partners for supporting this project.
+        <a href="/support">Learn more</a> about supporting The State of JS.
+
+    # opinions
+    - key: opinions.legends.never_heard
+      t: I've never heard of it
+    - key: opinions.legends_short.never_heard
+      t: Never heard of it  
+    - key: opinions.legends.not_interested
+      t: I've HEARD of it, and am NOT interested
+    - key: opinions.legends_short.not_interested
+      t: Heard of it, not interested
+    - key: opinions.legends.interested
+      t: I've HEARD of it, and WOULD like to learn it
+    - key: opinions.legends_short.interested
+      t: Heard of it, would like to learn
+    - key: opinions.legends.would_use  
+      t: I've USED it before, and WOULD use it again
+    - key: opinions.legends_short.would_use  
+      t: Used it, would use again
+    - key: opinions.legends.would_not_use  
+      t: I've USED it before, and would NOT use it again
+    - key: opinions.legends_short.would_not_use  
+      t: Used it, would not use again
+
+    # generic opinions
+    - key: opinion_scale.0
+      t: Strongly Disagree
+    - key: opinion_scale.1
+      t: Disagree
+    - key: opinion_scale.2
+      t: Neutral
+    - key: opinion_scale.3
+      t: Agree
+    - key: opinion_scale.4
+      t: Strongly Agree
+
+    # salary ranges
+    - key: salary_range.work-for-free.long
+      t: I work for free
+    - key: salary_range.work-for-free.short
+      t: work for free
+    - key: salary_range.0-10.long
+      t: $0k-$10k
+    - key: salary_range.0-10.short
+      t: $0k-$10k
+    - key: salary_range.10-30.long
+      t: $10k-$30k
+    - key: salary_range.10-30.short
+      t: $10k-$30k 
+    - key: salary_range.30-50.long
+      t: $30k-$50k
+    - key: salary_range.30-50.short
+      t: $30k-$50k 
+    - key: salary_range.50-100.long
+      t: $50k-$100k
+    - key: salary_range.50-100.short
+      t: $50k-$100k  
+    - key: salary_range.100-200.long
+      t: $100k-$200k
+    - key: salary_range.100-200.short
+      t: $100k-$200k   
+    - key: salary_range.more-than-200.long
+      t: more than $200k
+    - key: salary_range.more-than-200.short
+      t: $200k+   
+
+    # company size
+    - key: company_size.1.long
+      t: One employee
+    - key: company_size.1.short
+      t: one
+    - key: company_size.1-5.long
+      t: 1 to 5 employees
+    - key: company_size.1-5.short
+      t: 1~5
+    - key: company_size.5-10.long
+      t: 5 to 10 employees
+    - key: company_size.5-10.short
+      t: 5~10
+    - key: company_size.10-20.long
+      t: 10 to 20 employees
+    - key: company_size.10-20.short
+      t: 10~20
+    - key: company_size.20-50.long
+      t: 20 to 50 employees
+    - key: company_size.20-50.short
+      t: 20~50
+    - key: company_size.50-100.long
+      t: 50 to 100 employees
+    - key: company_size.50-100.short
+      t: 50~100
+    - key: company_size.100-1000.long
+      t: 100 to 1000 employees
+    - key: company_size.100-1000.short
+      t: 100~1000
+    - key: company_size.more-than-1000.long
+      t: More than 1000 employees
+    - key: company_size.more-than-1000.short
+      t: 1000+
+
+    # years of experience
+    - key: years_of_experience.less-than-1.long
+      t: Less than one year
+    - key: years_of_experience.less-than-1.short
+      t: '<1 year'
+    - key: years_of_experience.1-2.long
+      t: 1 to 2 years
+    - key: years_of_experience.1-2.short
+      t: 1~2 years
+    - key: years_of_experience.2-5.long
+      t: 2 to 5 years
+    - key: years_of_experience.2-5.short
+      t: 2~5 years
+    - key: years_of_experience.5-10.long
+      t: 5 to 10 years
+    - key: years_of_experience.5-10.short
+      t: 5~10 years
+    - key: years_of_experience.10-20.long
+      t: 10 to 20 years
+    - key: years_of_experience.10-20.short
+      t: 10~20 years
+    - key: years_of_experience.more-than-20.long
+      t: More than 20 years
+    - key: years_of_experience.more-than-20.short
+      t: '>20 years'
+
+    # sections
+    - key: section.javascript-flavors
+      t: JavaScript Flavors
+    - key: section.front-end-frameworks
+      t: Front-end Frameworks
+    - key: section.data-layer
+      t: Data Layer
+    - key: section.back-end-frameworks
+      t: Back-end Frameworks
+    - key: section.testing
+      t: Testing
+    - key: section.mobile-and-desktop
+      t: Mobile & Desktop
+
+    # tools
+    - key: tool.es6
+      t: ES6  
+    - key: tool.es6.description
+      t: |
+        ES6 and its descendants are the newer versions of JavaScript, usually run through Babel.
+    - key: tool.angular
+      t: Angular
+    - key: tool.angular.description
+      t: |
+        Angular is a TypeScript-based open-source front-end web application platform. Note that from
+        this year on we are not be making a distinction between Angular and Angular.js anymore, while datapoints for 
+        2016 and 2017 correspond to Angular (a.k.a. "Angular 2").
+    - key: tool.apollo
+      t: Apollo
+    - key: tool.apollo.description
+      t: |
+        A fully-featured, production ready caching GraphQL client for every UI framework and GraphQL server.
+    - key: tool.native-apps
+      t: Native Apps
+    - key: tool.native-apps.description
+      t: |
+        The majority of mobile and desktop apps are still built with native languages like Java, Kotlin, Objective-C, or Swift.
+    - key: tool.phonegap-cordova
+      t: Cordova
+    - key: tool.phonegap-cordova.description
+      t: |
+        Apache Cordova is a mobile application development framework.
+    - key: tool.vanilla-js
+      t: Vanilla JS
+    - key: tool.extjs
+      t: Ext JS
+    - key: tool.web-assembly
+      t: WebAssembly
+    - key: tool.firebase
+      t: Firebase
+    - key: tool.dotnet
+      t: .NET
+    - key: tool.rails
+      t: Rails
+    - key: tool.php
+      t: PHP
+    - key: tool.python
+      t: Python
+    - key: tool.laravel
+      t: Laravel
+    - key: tool.ruby
+      t: Ruby
+    - key: tool.elixir
+      t: Elixir
+    - key: tool.django
+      t: Django
+    - key: tool.golang
+      t: Go
+    - key: tool.C#
+      t: C#
+    - key: tool.java
+      t: Java
+    - key: tool.rust
+      t: Rust
+    - key: tool.haskell
+      t: Haskell
+    - key: tool.scala
+      t: Scala
+    - key: tool.selenium
+      t: Selenium
+    - key: tool.elm-test
+      t: elm-test
+    - key: tool.flutter
+      t: Flutter
+    - key: tool.pwa
+      t: Progressive Web Apps
+    - key: tool.weex
+      t: weex
+    - key: tool.xamarin
+      t: xamarin
+    - key: tool.appcelerator
+      t: Appcelerator
+    - key: tool.c-cplusplus
+      t: C/C++
+    - key: tool.swift
+      t: Swift
+    - key: tool.objective-c
+      t: Objective-C
+    - key: tool.ocaml
+      t: OCaml
+    - key: tool.parcel
+      t: Parcel
+    - key: tool.make
+      t: Make
+    - key: tool.lodash
+      t: lodash
+    - key: tool.moment
+      t: moment
+    - key: tool.underscore
+      t: underscore
+    - key: tool.date-fns
+      t: Date-fns
+    - key: tool.ramda
+      t: Ramda
+    - key: tool.luxon
+      t: luxon
+    - key: tool.visual-studio
+      t: VS Code
+    - key: tool.sublime-text
+      t: Sublime Text
+    - key: tool.webstorm
+      t: WebStorm
+    - key: tool.atom
+      t: Atom
+    - key: tool.emacs
+      t: emacs
+    - key: tool.intellij
+      t: IntelliJ
+    - key: tool.phpstorm
+      t: PhpStorm
+    - key: tool.notepad++
+      t: notepad++
+    - key: tool.brackets
+      t: Brackets
+    - key: tool.nano
+      t: nano
+    - key: tool.pycharm
+      t: PyCharm
+    - key: tool.vim
+      t: Vim
+    - key: tool.service-workers
+      t: Service Workers
+    - key: tool.webrtc
+      t: WebRTC
+    - key: tool.webvr
+      t: WebVR
+    - key: tool.webgl
+      t: WebGL
+    - key: tool.web-animations-api
+      t: Web Animations API
+    - key: tool.web-audio-api
+      t: Web Audio API
+    - key: tool.web-speech-api
+      t: Web Speech API
+
+    # pages
+    - key: page.introduction
+      t: Introduction
+    - key: page.demographics
+      t: Demographics
+    - key: page.connections
+      t: Connections
+    - key: page.section_overview
+      t: ${section} - Overview
+    - key: page.section_tool
+      t: ${section} - ${tool}
+    - key: page.section_overview.short
+      t: Overview
+    - key: page.section_other_tools
+      t: ${section} – Other Libraries
+    - key: page.section_other_tools.short
+      t: Other Libraries
+    - key: page.section_conclusion
+      t: ${section} - Conclusion
+    - key: page.section_conclusion.short
+      t: Conclusion
+    - key: page.other-tools
+      t: Other Tools
+    - key: page.opinions
+      t: Opinions
+    - key: page.awards
+      t: Awards 🏆
+    - key: page.conclusion
+      t: Conclusion
+    - key: page.support
+      t: Support Us
+
+    # blocks
+    - key: block.title.participation-by-country
+      t: Participation by Country
+    - key: block.description.participation-by-country
+      t: Survey participants by Country.
+    - key: block.title.salaries
+      t: Salaries
+    - key: block.description.salaries
+      t: Salary range breakdown.
+    - key: block.title.salary-per-country
+      t: Average Salary per Country
+    - key: block.description.salary-per-country
+      t: Average Salary per Country.
+    - key: block.title.years-of-experience
+      t: Years of Experience
+    - key: block.description.years-of-experience
+      t: Years of experience breakdown.
+    - key: block.title.company-size
+      t: Company Size
+    - key: block.description.company-size
+      t: Company size breakdown.
+    - key: block.title.gender-breakdown
+      t: Gender Breakdown
+    - key: block.title.source-breakdown
+      t: Source Breakdown
+    - key: block.description.gender-breakdown
+      t: Gender breakdown.
+    - key: block.title.connections
+      t: Connections Between Technologies
+    - key: block.description.connections
+      t: Connections between all libraries & technologies.
+    - key: block.title.overview
+      t: Overall Results
+    - key: block.description.overview
+      t: |
+        Overall ${section} results.
+    - key: block.title.results-over-time
+      t: ${tool}'s Popularity Over Time  
+    - key: block.description.results-over-time 
+      t: ${tool}'s popularity evolution over time.
+    - key: block.results-over-time.empty
+      t: |
+        Sorry, we don't have enough data to display
+        the evolution of this library's popularity over time. 
+    - key: block.title.happiness
+      t: Overall Happiness
+    - key: block.description.happiness
+      t: |
+        On a scale of one (very unhappy) to five (very happy), how happy are developers
+        with the current overall state of this category?
+    - key: block.title.tools-salary-range
+      t: Salary Breakdown
+    - key: block.description.tools-salary-range
+      t: |
+        Salary breakdown for developers who picked “used it, would use again” for a given option. 
+        
+        
+        Each cell shows the percentage of users in a given salary range,
+        darker means higher usage.
+    - key: block.title.tools-company-size
+      t: Company Size Breakdown
+    - key: block.description.tools-company-size
+      t: |
+        Company size breakdown for developers who picked “used it, would use again” for a given option.  
+        
+
+        Each cell shows the percentage of users in a given company size range,
+        darker means higher usage.
+    - key: block.title.tools-years-of-experience
+      t: Years Of Experience Breakdown
+    - key: block.description.tools-years-of-experience
+      t: |
+        Years of experience breakdown for developers who picked “used it, would use again” for a given option. 
+
+
+        Each cell shows the percentage of users in a given years of experience range,
+        darker means higher usage.
+    - key: block.title.likes    
+      t: Most Liked Aspects of ${tool}
+    - key: block.description.likes
+      t: |
+        Most liked aspects of ${tool} among developers who picked “used it and would use again”.
+    - key: block.title.dislikes    
+      t: Most Disliked Aspects of ${tool}   
+    - key: block.description.dislikes    
+      t: |
+        Most disliked aspects of ${tool} among developers who picked “used it and would *not* use again”.
+    - key: block.title.tool-pairing    
+      t: Which Tools Are Used Alongside ${tool}?
+    - key: block.description.tool-pairing
+      t: |
+        Libraries most likely to be used by developers who picked “used it and would use again” for ${tool}. 
+        Darker color means a stronger correlation.
+    - key: block.title.tool-usage-by-country
+      t: ${tool} Usage by Country    
+    - key: block.description.tool-usage-by-country
+      t: |
+        On average, **${percentage}%** of respondents have used **${tool}** and 
+        would be happy to use it again.
+        
+        
+        Countries where this ratio is higher are shown in red, those where it's lower
+        are displayed in blue (countries with fewer than 20 total survey respondents are
+        omitted).
+    - key: block.tool-usage-by-country.legend
+      t: |
+        Percentage of
+        happy ${tool} users:
+    - key: block.title.other-tools    
+      t: Other Libraries
+    - key: block.description.other-tools
+      t: |
+        Other answers mentioned by survey respondents, ranked by mention count.
+    - key: block.title.quadrants   
+      t: Quadrant Chart
+    - key: block.description.quadrants
+      t: |
+        This chart shows each technology’s **satisfaction ratio** over its **total usage**.
+
+
+        Additionally, technologies that have an **interest ratio** 
+        (percentage of non-users interested in learning it) over 50% are displayed as “on fire”.
+    - key: block.title.other_languages
+      t: Other Languages
+    - key: block.description.other_languages
+      t: Other languages, ranked by mention count.
+    - key: block.title.browser_apis
+      t: Browser APIs
+    - key: block.description.browser_apis
+      t: Browser APIs, ranked by mention count.
+    - key: block.title.build_tools
+      t: Build Tools
+    - key: block.description.build_tools
+      t: Build tools, ranked by mention count.
+    - key: block.title.utility_libraries
+      t: Utility Libraries
+    - key: block.description.utility_libraries
+      t: Utility libraries, ranked by mention count.
+    - key: block.title.text_editors
+      t: Text Editors
+    - key: block.description.text_editors
+      t: Text editors, ranked by mention count.
+    - key: block.title.recommended_resources
+      t: Recommended Resources
+    - key: block.title.opinion-js_moving_in_right_direction
+      t: JavaScript is moving in the right direction
+    - key: block.description.opinion-js_moving_in_right_direction
+      t: JavaScript is moving in the right direction.
+    - key: block.title.opinion-building_js_apps_overly_complex
+      t: Building JavaScript apps is overly complex right now
+    - key: block.description.opinion-building_js_apps_overly_complex
+      t: Building JavaScript apps is overly complex right now.
+    - key: block.title.opinion-js_over_used_online
+      t: JavaScript is over-used online
+    - key: block.description.opinion-js_over_used_online
+      t: JavaScript is over-used online.
+    - key: block.title.opinion-enjoy_building_js_apps
+      t: I enjoy building JavaScript apps
+    - key: block.description.opinion-enjoy_building_js_apps
+      t: I enjoy building JavaScript apps.
+    - key: block.title.opinion-would_like_js_to_be_main_lang
+      t: I would like JavaScript to be my main programming language
+    - key: block.description.opinion-would_like_js_to_be_main_lang
+      t: I would like JavaScript to be my main programming language.
+    - key: block.title.opinion-js_ecosystem_changing_to_fast
+      t: The JavaScript ecosystem is changing too fast
+    - key: block.description.opinion-js_ecosystem_changing_to_fast
+      t: The JavaScript ecosystem is changing too fast.
+    - key: block.title.opinion-survey_too_long
+      t: This survey is too damn long!
+    - key: block.description.opinion-survey_too_long
+      t: This survey is too damn long!
+
+    # reasons
+    - key: reason.elegant_programming_style_patterns.long
+      t: ⚙️ Elegant programming style & patterns
+    - key: reason.elegant_programming_style_patterns.short
+      t: ⚙️ Programming style
+    - key: reason.robust_less_error_prone_code.long
+      t: 🐞 Robust, less error-prone code
+    - key: reason.robust_less_error_prone_code.short
+      t: 🐞 Robust code
+    - key: reason.rich_package_ecosystem.long
+      t: 🎁 Rich package ecosystem
+    - key: reason.rich_package_ecosystem.short  
+      t: 🎁 Package ecosystem
+    - key: reason.fast_performance.long
+      t: ⚡ Fast performance
+    - key: reason.fast_performance.short  
+      t: ⚡ Fast performance
+    - key: reason.well_established_option.long
+      t: 🏛️ Well-established option
+    - key: reason.well_established_option.short  
+      t: 🏛️ Well-established
+    - key: reason.easy_learning_curve.long
+      t: 👶 Easy learning curve
+    - key: reason.easy_learning_curve.short
+      t: 👶 Easy to learn
+    - key: reason.powerful_developer_tooling.long
+      t: 🔧 Powerful developer tooling
+    - key: reason.powerful_developer_tooling.short
+      t: 🔧 Tooling
+    - key: reason.good_documentation.long
+      t: 📖 Good documentation
+    - key: reason.good_documentation.short
+      t: 📖 Documentation
+    - key: reason.backed_by_a_great_team_company.long
+      t: 👫 Backed by a great team/company
+    - key: reason.backed_by_a_great_team_company.short
+      t: 👫 Team/company
+    - key: reason.simple_lightweight.long
+      t: 🎈 Simple & lightweight
+    - key: reason.simple_lightweight.short
+      t: 🎈 Lightweight
+    - key: reason.growing_momentum_popularity.long
+      t: 📉 Growing momentum/popularity
+    - key: reason.growing_momentum_popularity.short
+      t: 📉 Momentum
+    - key: reason.full_featured_powerful.long
+      t: 🕹️ Full-featured & powerful
+    - key: reason.full_featured_powerful.short
+      t: 🕹️ Full-featured
+    - key: reason.stable_backwards_compatible.long
+      t: ⚖️ Stable & backwards-compatible
+    - key: reason.stable_backwards_compatible.short
+      t: ⚖️ Stability
+    - key: reason.clumsy_programming_style.long
+      t: ⚙️ Clumsy programming style
+    - key: reason.clumsy_programming_style.short
+      t: ⚙️ Clumsy
+    - key: reason.buggy_error_prone_code.long
+      t: 🐞 Buggy, error-prone code
+    - key: reason.buggy_error_prone_code.short
+      t: 🐞 Buggy code
+    - key: reason.poor_performance.long
+      t: ⚡ Poor performance
+    - key: reason.poor_performance.short
+      t: ⚡ Poor performance
+    - key: reason.small_package_ecosystem.long
+      t: 🎁 Small package ecosystem
+    - key: reason.small_package_ecosystem.short
+      t: 🎁 Few packages
+    - key: reason.new_untested_option.long
+      t: 🏛️ New untested option
+    - key: reason.new_untested_option.short
+      t: 🏛️ New & untested
+    - key: reason.hard_learning_curve.long
+      t: 👶 Hard learning curve
+    - key: reason.hard_learning_curve.short
+      t: 👶 Hard to learn
+    - key: reason.lacking_developer_tooling.long
+      t: 🔧 Lacking developer tooling
+    - key: reason.lacking_developer_tooling.short
+      t: 🔧 Lacking tooling
+    - key: reason.bad_documentation.long
+      t: 📖 Bad documentation
+    - key: reason.bad_documentation.short
+      t: 📖 Bad documentation
+    - key: reason.concerns_about_the_team_company.long
+      t: 👫 Concerns about the team/company
+    - key: reason.concerns_about_the_team_company.short
+      t: 👫 Bad team/company
+    - key: reason.bloated_complex.long
+      t: 🎈 Bloated & complex
+    - key: reason.bloated_complex.short
+      t: 🎈 Bloated & complex
+    - key: reason.diminishing_momentum_popularity.long
+      t: 📉 Diminishing momentum/popularity
+    - key: reason.diminishing_momentum_popularity.short
+      t: 📉 Low momentum
+    - key: reason.limited_lacking_in_features.long
+      t: 🕹️ Limited & lacking in features
+    - key: reason.limited_lacking_in_features.short
+      t: 🕹️ Limited
+    - key: reason.fast_changing_breaks_often.long
+      t: ⚖️ Fast-changing & breaks often
+    - key: reason.fast_changing_breaks_often.short
+      t: ⚖️ Fast-changing
+    - key: reason.other.long
+      t: Other
+    - key: reason.other.short
+      t: Other
+    
+    # quadrant
+    - key: quadrant.satisfaction_legend
+      t: Satisfaction %
+    - key: quadrant.users_legend
+      t: Users
+    - key: quadrant.assess.label
+      t: Assess
+    - key: quadrant.assess.description
+      t: |
+        Low usage, high satisfaction.
+        Technologies worth keeping an eye on.
+    - key: quadrant.adopt.label
+      t: Adopt
+    - key: quadrant.adopt.description
+      t: |
+        High usage, high satisfaction. Safe technologies to adopt.
+    - key: quadrant.avoid.label
+      t: Avoid
+    - key: quadrant.avoid.description
+      t: |
+        Low usage, low satisfaction.
+        Technologies probably best avoided currently.
+    - key: quadrant.analyze.label
+      t: Analyze
+    - key: quadrant.analyze.description
+      t: |
+        High usage, low satisfaction.
+        Reassess these technologies if you're currently using them.
+
+    # awards
+    - key: block.title.highest_satisfaction
+      t: Highest Satisfaction
+    - key: block.description.highest_satisfaction
+      t: |
+        Awarded to the library with the highest percentage of satisfied users.
+    - key: award.highest_satisfaction.comment
+      t: |
+        With **${tools[0].percentage}%** of users willing to use it again,
+        ${tools[0].label} proves it’s not kidding around.
+    - key: award.highest_satisfaction.runner_up
+      t: ${tool.label} ${tool.percentage}%  
+    - key: block.title.highest_interest
+      t: Highest Interest
+    - key: block.description.highest_interest
+      t: |
+        Awarded to the technology developers are most interested in learning.
+    - key: award.highest_interest.comment
+      t: |
+        **${tools[0].percentage}%** of developers who have heard about
+        ${tools[0].label} want to learn it.
+        That’s some serious interest!
+    - key: award.highest_interest.runner_up
+      t: ${tool.label} ${tool.percentage}%
+    - key: block.title.highest_usage
+      t: Most Used
+    - key: block.description.highest_usage
+      t: |
+        Awarded to technology with the largest user base.
+    - key: award.highest_usage.comment
+      t: |
+        With **${tools[0].count}** users ${tools[0].label}
+        is the most used library this year.        
+    - key: award.highest_usage.runner_up
+      t: ${tool.label} ${tool.count}
+    - key: block.title.most_mentioned
+      t: Most Mentioned
+    - key: block.description.most_mentioned
+      t: |
+        Awarded to the library mentioned the most in the “other libraries” answer. 
+    - key: award.most_mentioned.comment
+      t: |
+        ${tools[0].label} collected **${tools[0].count}** mentions,
+        making it the most submitted freeform answer by far.
+    - key: award.most_mentioned.runner_up
+      t: ${tool.label} ${tool.count}
+    - key: block.title.prediction
+      t: Prediction Award
+    - key: block.description.prediction
+      t: |
+        Awarded to an up-and-coming technology that might take over… or not?
+    - key: award.prediction.comment
+      t: |
+        The Facebook team is two for two with React and GraphQL.
+        Will Reason follow the same path?
+    - key: award.prediction.runner_up
+      t: ${tool.label}
+    - key: block.title.special
+      t: Special Award
+    - key: block.description.special
+      t: |
+        Awarded to a technology that we just fell in love with this year.
+    - key: award.special.comment
+      t: |
+        ${tools[0].label} has become the leading JavaScript text editor, and we can definitely see why!
+    - key: award.special.runner_up
+      t: ${tool.label}
+
+    # sharing
+    - key: share.site.title
+      t: Discover the StateOf JavaScript 2018 results
+    - key: share.site.twitter_text
+      t: 'Discover the State Of JavaScript 2018 results ${link} #StateOfJS'
+    - key: share.site.subject
+      t: State Of JavaScript Survey Results
+    - key: share.site.body
+      t: 'Here are some interesting JavaScript survey results: ${link}'
+    - key: share.block.twitter_text
+      t: '#StateOfJS 2018: ${title} ${link}'
+    - key: share.block.subject
+      t: State Of JavaScript Survey Results
+    - key: share.block.body
+      t: 'Here are some interesting JavaScript survey results (${title}): ${link}'

--- a/surveys/2018/website/src/translations/hu-HU.yml
+++ b/surveys/2018/website/src/translations/hu-HU.yml
@@ -6,7 +6,7 @@ translations:
     - key: average
       t: Átlag  
     - key: conclusion  
-      t: Conclusion
+      t: Következtetés
     - key: tools_salary_range_average
       t: Átlagos kereset
     - key: tools_company_size_average
@@ -174,7 +174,7 @@ translations:
     - key: section.front-end-frameworks
       t: Front-end keretrendszerek
     - key: section.data-layer
-      t: Data Layer
+      t: Adat réteg
     - key: section.back-end-frameworks
       t: Back-end keretrendszerek
     - key: section.testing

--- a/surveys/2018/website/src/translations/hu-HU.yml
+++ b/surveys/2018/website/src/translations/hu-HU.yml
@@ -2,87 +2,87 @@ locale: hu-HU
 translations:
     # general
     - key: share
-      t: Share
+      t: Megosztás
     - key: average
-      t: Average  
+      t: Átlag  
     - key: conclusion  
       t: Conclusion
     - key: tools_salary_range_average
-      t: Average salary
+      t: Átlagos kereset
     - key: tools_company_size_average
-      t: Average company size
+      t: Átlagos cégméret
     - key: tools_years_of_experience_average
-      t: Average years of experience
+      t: Átlag tapasztalat (év)
     - key: users_percentage
-      t: percentage of users
+      t: Felhasználók százalékos aránya
     - key: salary_range_axis_legend
-      t: salary range
+      t: fizetési tartomány
     - key: years_of_experience_axis_legend
-      t: years of experience
+      t: tapasztalat (év)
     - key: company_size_axis_legend
-      t: number of employees
+      t: alkalmazottak száma
     - key: percents_display_mode
-      t: Percents
+      t: Százalékok
     - key: counts_display_mode
-      t: Counts
+      t: Számlálók
     - key: awards_runner_ups
-      t: Runner-Ups
+      t: Másodlagos befutók
     - key: tool_homepage
-      t: Homepage
+      t: Főoldal
     - key: from_to_short
-      t: ${from} to ${to}
+      t: ${from}-tól ${to}-ig
     - key: users_count
-      t: ${count} users
+      t: ${count} felhasználó
     - key: percentage_of_respondents
-      t: ${percentage} of respondents
+      t: ${percentage} válaszadó
     - key: partners.premium_partners
-      t: Our 2018 Premium Partners
+      t: 2018-as Prémium Partnereink
     - key: partners.become_partner
-      t: Become a partner
+      t: Légy te is partner
     - key: partners.thanks
       t: |
-        Thanks to our partners for supporting this project.
-        <a href="/support">Learn more</a> about supporting The State of JS.
+        Minden partnerünknek köszönjük, hogy a támogatják ezt a projektet.
+        <a href="/support">További információ</a> a The State of JS támogatásáról.
 
     # opinions
     - key: opinions.legends.never_heard
-      t: I've never heard of it
+      t: Soha nem hallottam róla
     - key: opinions.legends_short.never_heard
-      t: Never heard of it  
+      t: Soha nem hallotta  
     - key: opinions.legends.not_interested
-      t: I've HEARD of it, and am NOT interested
+      t: HALLOTTAM róla, de NEM érdekel
     - key: opinions.legends_short.not_interested
-      t: Heard of it, not interested
+      t: Hallotta, nem érdekli
     - key: opinions.legends.interested
-      t: I've HEARD of it, and WOULD like to learn it
+      t: HALLOTTAM róla, és ÉRDEKEL is
     - key: opinions.legends_short.interested
-      t: Heard of it, would like to learn
+      t: Hallott róla, érdekli
     - key: opinions.legends.would_use  
-      t: I've USED it before, and WOULD use it again
+      t: HASZNÁLTAM korábban, használnám megint
     - key: opinions.legends_short.would_use  
-      t: Used it, would use again
+      t: Használta korábban, használná megint
     - key: opinions.legends.would_not_use  
-      t: I've USED it before, and would NOT use it again
+      t: HASZNÁLTAM korábban, NEM használnám megint
     - key: opinions.legends_short.would_not_use  
-      t: Used it, would not use again
+      t: Használta korábban, nem használná megint
 
     # generic opinions
     - key: opinion_scale.0
-      t: Strongly Disagree
+      t: Erősen nem ért egyet
     - key: opinion_scale.1
-      t: Disagree
+      t: Nem ért egyet
     - key: opinion_scale.2
-      t: Neutral
+      t: Neutrális
     - key: opinion_scale.3
-      t: Agree
+      t: Egyet ért
     - key: opinion_scale.4
-      t: Strongly Agree
+      t: Erősen egyet ért
 
     # salary ranges
     - key: salary_range.work-for-free.long
-      t: I work for free
+      t: Ingyen dolgozom
     - key: salary_range.work-for-free.short
-      t: work for free
+      t: ingyen dolgozik
     - key: salary_range.0-10.long
       t: $0k-$10k
     - key: salary_range.0-10.short
@@ -104,83 +104,83 @@ translations:
     - key: salary_range.100-200.short
       t: $100k-$200k   
     - key: salary_range.more-than-200.long
-      t: more than $200k
+      t: több mint $200k
     - key: salary_range.more-than-200.short
       t: $200k+   
 
     # company size
     - key: company_size.1.long
-      t: One employee
+      t: Egy alkalmazott
     - key: company_size.1.short
-      t: one
+      t: egy
     - key: company_size.1-5.long
-      t: 1 to 5 employees
+      t: 1-5 alkalmazott
     - key: company_size.1-5.short
       t: 1~5
     - key: company_size.5-10.long
-      t: 5 to 10 employees
+      t: 5-10 alkalmazott
     - key: company_size.5-10.short
       t: 5~10
     - key: company_size.10-20.long
-      t: 10 to 20 employees
+      t: 10-20 alkalmazott
     - key: company_size.10-20.short
       t: 10~20
     - key: company_size.20-50.long
-      t: 20 to 50 employees
+      t: 20-50 alkalmazott
     - key: company_size.20-50.short
       t: 20~50
     - key: company_size.50-100.long
-      t: 50 to 100 employees
+      t: 50-100 alkalmazott
     - key: company_size.50-100.short
       t: 50~100
     - key: company_size.100-1000.long
-      t: 100 to 1000 employees
+      t: 100-1000 alkalmazott
     - key: company_size.100-1000.short
       t: 100~1000
     - key: company_size.more-than-1000.long
-      t: More than 1000 employees
+      t: Több mint 1000 alkalmazott
     - key: company_size.more-than-1000.short
       t: 1000+
 
     # years of experience
     - key: years_of_experience.less-than-1.long
-      t: Less than one year
+      t: Kevesebb mint egy év
     - key: years_of_experience.less-than-1.short
-      t: '<1 year'
+      t: '<1 év'
     - key: years_of_experience.1-2.long
-      t: 1 to 2 years
+      t: 1-2 év
     - key: years_of_experience.1-2.short
-      t: 1~2 years
+      t: 1~2 év
     - key: years_of_experience.2-5.long
-      t: 2 to 5 years
+      t: 2-5 év
     - key: years_of_experience.2-5.short
-      t: 2~5 years
+      t: 2~5 év
     - key: years_of_experience.5-10.long
-      t: 5 to 10 years
+      t: 5-10 év
     - key: years_of_experience.5-10.short
-      t: 5~10 years
+      t: 5~10 év
     - key: years_of_experience.10-20.long
-      t: 10 to 20 years
+      t: 10-20 év
     - key: years_of_experience.10-20.short
-      t: 10~20 years
+      t: 10~20 év
     - key: years_of_experience.more-than-20.long
-      t: More than 20 years
+      t: Több mint 20 év
     - key: years_of_experience.more-than-20.short
-      t: '>20 years'
+      t: '>20 év'
 
     # sections
     - key: section.javascript-flavors
       t: JavaScript Flavors
     - key: section.front-end-frameworks
-      t: Front-end Frameworks
+      t: Front-end keretrendszerek
     - key: section.data-layer
       t: Data Layer
     - key: section.back-end-frameworks
-      t: Back-end Frameworks
+      t: Back-end keretrendszerek
     - key: section.testing
-      t: Testing
+      t: Tesztelés
     - key: section.mobile-and-desktop
-      t: Mobile & Desktop
+      t: Mobil & Asztali
 
     # tools
     - key: tool.es6
@@ -325,11 +325,11 @@ translations:
 
     # pages
     - key: page.introduction
-      t: Introduction
+      t: Bemutatkozás
     - key: page.demographics
-      t: Demographics
+      t: Demográfia
     - key: page.connections
-      t: Connections
+      t: Kapcsolatok
     - key: page.section_overview
       t: ${section} - Overview
     - key: page.section_tool
@@ -337,23 +337,23 @@ translations:
     - key: page.section_overview.short
       t: Overview
     - key: page.section_other_tools
-      t: ${section} – Other Libraries
+      t: ${section} – Egyéb könyvtárak
     - key: page.section_other_tools.short
-      t: Other Libraries
+      t: Egyéb könyvtárak
     - key: page.section_conclusion
-      t: ${section} - Conclusion
+      t: ${section} - Következtetések
     - key: page.section_conclusion.short
-      t: Conclusion
+      t: Következtetések
     - key: page.other-tools
-      t: Other Tools
+      t: Egyéb eszközök
     - key: page.opinions
-      t: Opinions
+      t: Vélemények
     - key: page.awards
-      t: Awards 🏆
+      t: Díjak 🏆
     - key: page.conclusion
-      t: Conclusion
+      t: Következtetés
     - key: page.support
-      t: Support Us
+      t: Támogass minket
 
     # blocks
     - key: block.title.participation-by-country

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/back-end-frameworks-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/back-end-frameworks-conclusion.md
@@ -1,0 +1,10 @@
+---
+type: conclusion
+section: back-end-frameworks
+locale: en-US
+---
+ JavaScript on the server is in a weird state. While countless frameworks emerge every year, very few manage to gain enough momentum to challenge **Express**. Even **Koa**, sometimes billed as Express' successor, has a lower satisfaction ratio (and vastly lower usage numbers).
+
+One interesting entrant in the space is **Next.js**, which has been generating a lot of interest lately. Although it's not quite comparable to a full-featured Node back-end, its single-minded focus on solving the server-side-rendering problem for React apps has made it a very useful tool. 
+
+It's also interesting to see what role serverless technologies like [AWS Lambda](https://aws.amazon.com/lambda/) will play over the next couple of years. Who knows, the back-end category as we know it might soon be a thing of the past!

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/back-end-frameworks-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/back-end-frameworks-conclusion.md
@@ -1,7 +1,7 @@
 ---
 type: conclusion
 section: back-end-frameworks
-locale: en-US
+locale: hu-HU
 ---
  JavaScript on the server is in a weird state. While countless frameworks emerge every year, very few manage to gain enough momentum to challenge **Express**. Even **Koa**, sometimes billed as Express' successor, has a lower satisfaction ratio (and vastly lower usage numbers).
 

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/conclusion-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/conclusion-conclusion.md
@@ -1,0 +1,16 @@
+---
+type: conclusion
+section: conclusion
+locale: en-US
+---
+ After all is said and done, it looks like 2018 was mostly a continuation of the trends we already observed [last year](http://2017.stateofjs.com).
+
+That's bad news for us, because we can't come out with a big scoop on how React's days are numbered, or the next big thing is this new state management library created by a 17-year-old Vietnamese high-schooler in her spare time. 
+
+But that's great news for you, because it means you can spend less time worrying about what to use, and more time actually using it!
+
+Things might get shaken up again in 2019 though. While all is currently calm on the front-end front, the question of how you get data from the database to the client is far from settled, and GraphQL is sure to start making bigger and bigger waves in that area. As GraphQL-tailored solutions emerge for both the back-end and the state management layer, we might soon feel the JavaScript ground shifting beneath our feet once more.
+
+But for now, no need to panic. There's never been a better time to be a JavaScript developer than now, and we're willing to bet that 2019 will make that even clearer!
+
+<span class="conclusion__byline">– Sacha, Raphaël, and Michael</span>

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/conclusion-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/conclusion-conclusion.md
@@ -1,7 +1,7 @@
 ---
 type: conclusion
 section: conclusion
-locale: en-US
+locale: hu-HU
 ---
  After all is said and done, it looks like 2018 was mostly a continuation of the trends we already observed [last year](http://2017.stateofjs.com).
 

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/data-layer-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/data-layer-conclusion.md
@@ -1,0 +1,12 @@
+---
+type: conclusion
+section: data-layer
+locale: en-US
+---
+ In the good old days, things were simple. Your data lived in your database, where the server could fetch it, plop it into a template, and send the whole thing down to the client. 
+
+But things are not so simple anymore. Today, apps need to know how to fetch data themselves in order to render their own templates and components. This has given rise to a whole range of data fetching and data management tools. 
+
+**Redux** is without a doubt the most widespread of these tools, and its 82% satisfaction rate is a testament to how well-regarded it has become. 
+
+But the whole space might soon get shaken up by the **GraphQL** shockwave. **GraphQL** users went from 5% to 20% in two years, and their client of choice seems to be **Apollo**. Add to this the fact that the latest version of Apollo makes using Redux optional, and it wouldn't be surprising if next year's results start to look very different… 

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/data-layer-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/data-layer-conclusion.md
@@ -1,7 +1,7 @@
 ---
 type: conclusion
 section: data-layer
-locale: en-US
+locale: hu-HU
 ---
  In the good old days, things were simple. Your data lived in your database, where the server could fetch it, plop it into a template, and send the whole thing down to the client. 
 

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/front-end-frameworks-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/front-end-frameworks-conclusion.md
@@ -1,0 +1,12 @@
+---
+type: conclusion
+section: front-end-frameworks
+locale: en-US
+---
+Once again the front-end space is all about **React** and **Vue.js**. Vue's story in particular is worth considering: two years ago, 27% of respondents had never even heard of the library. Today, that fraction has fallen to just 1.3%! So while React still has a much larger share of the market, Vue's meteoric rise certainly shows no sign of stopping. In fact, Vue has already overtaken its rival for certain metrics such as total GitHub stars. 
+
+The other story of those past couple years is the fall of **Angular**. While it still ranks very high in terms of raw usage, it has a fairly disappointing 41% satisfaction ratio. So while it probably isn't going anywhere thanks to its large user base, it's hard to see how it will ever regain its place atop the front-end throne. 
+
+Finally, keep an eye out for [Svelte](https://svelte.technology/). By using a radical new approach to front-end frameworks, it's managed to generate quite a lot of interest and was by far the most mentioned option in our "Other Tools" category. 
+
+Update: many people have pointed out that Angular's poor satisfaction ratio is probably in part due to the confusion between Angular and the older, deprecated AngularJS (previous surveys avoided this issue by featuring both as separate items). So while Angular did “fall” –relatively speaking– from its dominance from a few years back, it might very well regain ground once the dust clears.

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/front-end-frameworks-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/front-end-frameworks-conclusion.md
@@ -1,7 +1,7 @@
 ---
 type: conclusion
 section: front-end-frameworks
-locale: en-US
+locale: hu-HU
 ---
 Once again the front-end space is all about **React** and **Vue.js**. Vue's story in particular is worth considering: two years ago, 27% of respondents had never even heard of the library. Today, that fraction has fallen to just 1.3%! So while React still has a much larger share of the market, Vue's meteoric rise certainly shows no sign of stopping. In fact, Vue has already overtaken its rival for certain metrics such as total GitHub stars. 
 

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/javascript-flavors-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/javascript-flavors-conclusion.md
@@ -1,0 +1,12 @@
+---
+type: conclusion
+section: javascript-flavors
+locale: en-US
+---
+ The idea that you can write your code in a language or language variant that compiles down to JavaScript may seem obvious now, but it's easy to forget how innovative it really is. 
+
+For the longest time CoffeeScript was the lone proponent of that strategy, but today it's been overtaken by **ES6** and its follow-ups, **TypeScript**, **Flow**, and even languages with very different syntaxes such as **Elm** and **Reason**. 
+
+And there're good reasons to think that this is the future of JavaScript as a whole. With projects like [Web Assembly](https://webassembly.org/) arriving on the scene, writing code directly in JavaScript might soon seem quaint as developers embrace languages like **Rust** instead. 
+
+But until that time, the two big winners here are **ES6** and **TypeScript**. Keep an eye out on **Reason** as well, which has Facebook's support and boasts both very high satisfaction and interest rates.

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/javascript-flavors-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/javascript-flavors-conclusion.md
@@ -1,7 +1,7 @@
 ---
 type: conclusion
 section: javascript-flavors
-locale: en-US
+locale: hu-HU
 ---
  The idea that you can write your code in a language or language variant that compiles down to JavaScript may seem obvious now, but it's easy to forget how innovative it really is. 
 

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/mobile-and-desktop-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/mobile-and-desktop-conclusion.md
@@ -1,0 +1,16 @@
+---
+type: conclusion
+section: mobile-and-desktop
+locale: en-US
+---
+ This category shows clearly how JavaScript has expanded its "scope" far beyond the limits of the browser.
+
+**React Native** and **Electron** are the two leading solutions to build mobile and desktop apps using web technologies. Coincidentally, they show similar numbers in both satisfaction ratio and number of users.
+
+Electron's versatility (it can work with any UI framework, even if it's often associated with React or Vue.js) may explain why it got the highest satisfaction ratio of the category.
+
+But things are far from settled: Airbnb recently published [a thorough series of article](https://medium.com/airbnb-engineering/react-native-at-airbnb-f95aa460be1c) explaining why they decided to drop React Native for their next products in favor of Native Apps.
+
+As an alternative to React Native, developers who want to write cross-platform applications in JavaScript without using React patterns can check out [Weex](https://weex.apache.org/), which lets them use the Vue.js eco-system.
+
+And Google has many interesting entrants in the space as well. There's [Carlo](https://github.com/GoogleChromeLabs/carlo), a brand new “Headful Node app framework” released by Google and built on top of [Puppeteer](https://github.com/GoogleChromeLabs/carlo); as well as [Flutter](https://flutter.io/): instead of building a JavaScript "bridge" as React Native does, it compiles to true native code. But the code is written in Dart, so at the end of the day React Native will be still relevant to most of JavaScript developers already familiar with the React system.

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/mobile-and-desktop-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/mobile-and-desktop-conclusion.md
@@ -1,7 +1,7 @@
 ---
 type: conclusion
 section: mobile-and-desktop
-locale: en-US
+locale: hu-HU
 ---
  This category shows clearly how JavaScript has expanded its "scope" far beyond the limits of the browser.
 

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/testing-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/testing-conclusion.md
@@ -1,0 +1,18 @@
+---
+type: conclusion
+section: testing
+locale: en-US
+---
+ The testing space is a bit of an oddity: while the other parts of the JavaScript ecosystem have been slowly settling down around a few dominant solutions, testing is still very fragmented: lots of different, complementary tools share the pie. Even so, developers are satisfied by their testing solution overall, with the lowest satisfaction ratio being 68%.
+
+The survey confirms that **Mocha** is still the most used unit testing framework with over 10k users. Being around for a long time, it has the largest ecosystem and most of the Node.js developers are familiar with it.
+
+**Jest** follows closely in terms of usage but it has a slightly higher satisfaction rate: 96% versus 82%. As a side note, 96% is the second highest satisfaction in the whole survey this year. Only ES6 got a better mark!
+
+This shows that developers really appreciate the efforts made by Facebook to provide a full-featured testing framework that can be used to test both front-end (it was intended to test React components, in the beginning) and back-end code, without requiring configuration.
+
+In the "Single Page application" era, web applications are becoming more and more complex, with more and more logic implemented on the client side. The survey shows clearly that developers use many tools to test their applications.
+
+The spectrum of testing is wide: unit tests, integration tests, end-to-end tests but also "visual testing", as we can see with the success of **Storybook** (the second highest satisfaction rate of the category).
+
+The future of testing may include more solutions to make automated tests in the browser, a project like [Cypress](https://www.cypress.io/) may be included in the next year survey and we may see more tools based on [Puppeteer](https://pptr.dev/).

--- a/surveys/2018/website/src/translations/hu-HU/conclusions/testing-conclusion.md
+++ b/surveys/2018/website/src/translations/hu-HU/conclusions/testing-conclusion.md
@@ -1,7 +1,7 @@
 ---
 type: conclusion
 section: testing
-locale: en-US
+locale: hu-HU
 ---
  The testing space is a bit of an oddity: while the other parts of the JavaScript ecosystem have been slowly settling down around a few dominant solutions, testing is still very fragmented: lots of different, complementary tools share the pie. Even so, developers are satisfied by their testing solution overall, with the lowest satisfaction ratio being 68%.
 

--- a/surveys/2018/website/src/translations/hu-HU/introductions/awards-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/awards-introduction.md
@@ -1,0 +1,7 @@
+---
+type: introduction
+section: awards
+locale: en-US
+---
+ Join us for the first ever State of JS awards! Can you guess which technologies took gold
+in each category? <span class="note">(Note: we've excluded ES6 from the awards to avoid skewing the data)</span>

--- a/surveys/2018/website/src/translations/hu-HU/introductions/awards-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/awards-introduction.md
@@ -1,7 +1,7 @@
 ---
 type: introduction
 section: awards
-locale: en-US
+locale: hu-HU
 ---
  Join us for the first ever State of JS awards! Can you guess which technologies took gold
 in each category? <span class="note">(Note: we've excluded ES6 from the awards to avoid skewing the data)</span>

--- a/surveys/2018/website/src/translations/hu-HU/introductions/back-end-frameworks-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/back-end-frameworks-introduction.md
@@ -1,0 +1,8 @@
+---
+type: introduction
+section: back-end-frameworks
+locale: en-US
+---
+ JavaScript on the back-end hasn't seen any major breakthroughs in recent years. 
+But compared to the rest of the ecosystem's frenetic pace,
+many will say that this is a blessing, not a curse. 

--- a/surveys/2018/website/src/translations/hu-HU/introductions/back-end-frameworks-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/back-end-frameworks-introduction.md
@@ -1,7 +1,7 @@
 ---
 type: introduction
 section: back-end-frameworks
-locale: en-US
+locale: hu-HU
 ---
  JavaScript on the back-end hasn't seen any major breakthroughs in recent years. 
 But compared to the rest of the ecosystem's frenetic pace,

--- a/surveys/2018/website/src/translations/hu-HU/introductions/connections-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/connections-introduction.md
@@ -1,0 +1,10 @@
+---
+type: introduction
+section: connections
+locale: en-US
+---
+How many *React* users also use *Redux*? Do *GraphQL* fans prefer *Jest*? 
+Are *Express* developers also into *Ember*?
+
+The size of each section corresponds to the number of respondents who have used each library
+and would be willing to use it again.

--- a/surveys/2018/website/src/translations/hu-HU/introductions/connections-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/connections-introduction.md
@@ -1,7 +1,7 @@
 ---
 type: introduction
 section: connections
-locale: en-US
+locale: hu-HU
 ---
 How many *React* users also use *Redux*? Do *GraphQL* fans prefer *Jest*? 
 Are *Express* developers also into *Ember*?

--- a/surveys/2018/website/src/translations/hu-HU/introductions/data-layer-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/data-layer-introduction.md
@@ -1,0 +1,8 @@
+---
+type: introduction
+section: data-layer
+locale: en-US
+---
+ The data layer regroups all the technologies used to transmit and manage data. 
+It's a vast category where many approaches compete to make a tricky problem more
+approachable.

--- a/surveys/2018/website/src/translations/hu-HU/introductions/data-layer-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/data-layer-introduction.md
@@ -1,7 +1,7 @@
 ---
 type: introduction
 section: data-layer
-locale: en-US
+locale: hu-HU
 ---
  The data layer regroups all the technologies used to transmit and manage data. 
 It's a vast category where many approaches compete to make a tricky problem more

--- a/surveys/2018/website/src/translations/hu-HU/introductions/demographics-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/demographics-introduction.md
@@ -1,0 +1,11 @@
+---
+type: introduction
+section: demographics
+locale: en-US
+---
+
+This year, we reached 20,268 developers in 153 different countries. While the **U.S.** dominates the survey as expected with 24% of respondents, **Germany** and **Australia** are both well-represented, with over 5% of respondents each. 
+
+Of course, we should mention that although we're doing our best to get as many developers as we can to fill out the survey, our audience is still only a small fraction of the overall JavaScript community, and you should keep this in mind when evaluating the following results.  
+
+Note: one factor that could definitely help us reach broader, more international audiences in the future would be translating the survey and survey results in multiple languages. If you think you can help, please [let us know](https://github.com/StateOfJS/StateOfJS/issues/87)!

--- a/surveys/2018/website/src/translations/hu-HU/introductions/demographics-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/demographics-introduction.md
@@ -1,7 +1,7 @@
 ---
 type: introduction
 section: demographics
-locale: en-US
+locale: hu-HU
 ---
 
 This year, we reached 20,268 developers in 153 different countries. While the **U.S.** dominates the survey as expected with 24% of respondents, **Germany** and **Australia** are both well-represented, with over 5% of respondents each. 

--- a/surveys/2018/website/src/translations/hu-HU/introductions/front-end-frameworks-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/front-end-frameworks-introduction.md
@@ -1,0 +1,8 @@
+---
+type: introduction
+section: front-end-frameworks
+locale: en-US
+---
+The front-end remains the key battleground for JavaScript. But now
+that the dust has cleared, it's starting to look like only two
+combatants are left standing…

--- a/surveys/2018/website/src/translations/hu-HU/introductions/front-end-frameworks-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/front-end-frameworks-introduction.md
@@ -1,7 +1,7 @@
 ---
 type: introduction
 section: front-end-frameworks
-locale: en-US
+locale: hu-HU
 ---
 The front-end remains the key battleground for JavaScript. But now
 that the dust has cleared, it's starting to look like only two

--- a/surveys/2018/website/src/translations/hu-HU/introductions/introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/introduction.md
@@ -1,0 +1,43 @@
+---
+type: introduction
+section: introduction
+locale: en-US
+---
+ 
+<span class="first-line"><span class="first-letter">JavaScript</span> is always changing.</span> New libraries, new frameworks, new languages… It's part of the fun, but it can also feel overwhelming sometimes. 
+
+That's where the State of JavaScript survey comes in: this year, we surveyed over 20,000 JavaScript developers to figure out what they're using, what they're happy with, and what they want to learn. And the result is a unique collection of stats and insights that will hopefully help you make your own way through the JavaScript ecosystem. 
+
+If you want to learn more about what's new this year, check out our [announcement post](https://medium.freecodecamp.org/the-state-of-javascript-2018-8322bcc51bd8) for more details.
+
+### Resources
+
+We figure a lot of you are checking out this survey to help you figure out what to learn next. So we've included links to useful JavaScript resources throughout the survey to help point you in the right direction. 
+
+Full disclosure: some of them are paid sponsorships, but no matter what they're all high-quality resources from people we know and respect who have decided to support our project. 
+
+### Team
+
+The State of JavaScript Survey is created and maintained by:
+
+- [Sacha Greif](https://twitter.com/sachagreif) (me!): Design, writing, coding
+- [Raphael Benitte](https://twitter.com/benitteraphael): Data analysis, visualizations
+- [Michael Rambeau](https://twitter.com/michaelrambeau): Writing, additional stats
+
+Be sure to check out my React/GraphQL JavaScript framework, [Vulcan.js](http://vulcanjs.org), Raphael's React data visualization library [Nivo.js](https://nivo.rocks), and Michael's JavaScript library directory [Best of JS](https://bestofjs.org).
+
+### Other Links
+
+- [State of JavaScript Homepage](https://stateofjs.com)
+- [2016](https://2016.stateofjs.com/)
+- [2017](https://2017.stateofjs.com/)
+
+### Credits & Stuff
+
+The site is set in IBM Plex Mono. Fire gif borrowed from [Animal Jam](https://animal-jam-roleplay.wikia.com/wiki/File:Pixel-fire-gif-1.gif). Questions? Feedback? Want access to the raw data? [Get in touch!](mailto:hello@stateofjs.com)
+
+And now, let's see what JavaScript has been up to this year!
+
+P.S. We put a lot of work and care into this year's site, so please don't go clicking around breaking things!
+
+<span class="conclusion__byline">– Sacha, Raphaël, and Michael</span>

--- a/surveys/2018/website/src/translations/hu-HU/introductions/introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/introduction.md
@@ -1,7 +1,7 @@
 ---
 type: introduction
 section: introduction
-locale: en-US
+locale: hu-HU
 ---
  
 <span class="first-line"><span class="first-letter">JavaScript</span> is always changing.</span> New libraries, new frameworks, new languages… It's part of the fun, but it can also feel overwhelming sometimes. 

--- a/surveys/2018/website/src/translations/hu-HU/introductions/javascript-flavors-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/javascript-flavors-introduction.md
@@ -1,0 +1,8 @@
+---
+type: introduction
+section: javascript-flavors
+locale: en-US
+---
+ As JavaScript matures, developers are starting to look
+beyond its borders and create various languages and dialects that
+compile to JavaScript.

--- a/surveys/2018/website/src/translations/hu-HU/introductions/javascript-flavors-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/javascript-flavors-introduction.md
@@ -1,7 +1,7 @@
 ---
 type: introduction
 section: javascript-flavors
-locale: en-US
+locale: hu-HU
 ---
  As JavaScript matures, developers are starting to look
 beyond its borders and create various languages and dialects that

--- a/surveys/2018/website/src/translations/hu-HU/introductions/mobile-and-desktop-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/mobile-and-desktop-introduction.md
@@ -1,0 +1,8 @@
+---
+type: introduction
+section: mobile-and-desktop
+locale: en-US
+---
+ “Any application that can be written in JavaScript, will eventually be written in JavaScript.”
+JavaScript is not limited to the browser anymore, and it's only
+a matter of time until your smart toaster burns your bread because NPM is down. 

--- a/surveys/2018/website/src/translations/hu-HU/introductions/mobile-and-desktop-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/mobile-and-desktop-introduction.md
@@ -1,7 +1,7 @@
 ---
 type: introduction
 section: mobile-and-desktop
-locale: en-US
+locale: hu-HU
 ---
  “Any application that can be written in JavaScript, will eventually be written in JavaScript.”
 JavaScript is not limited to the browser anymore, and it's only

--- a/surveys/2018/website/src/translations/hu-HU/introductions/opinions-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/opinions-introduction.md
@@ -1,0 +1,6 @@
+---
+type: introduction
+section: opinions
+locale: en-US
+---
+ Cold, hard data has its place, but there's also something to be said for personal opinion. That's why each year, we ask a few questions to try and get a feel for the pulse of the JavaScript developer community. 

--- a/surveys/2018/website/src/translations/hu-HU/introductions/opinions-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/opinions-introduction.md
@@ -1,6 +1,6 @@
 ---
 type: introduction
 section: opinions
-locale: en-US
+locale: hu-HU
 ---
  Cold, hard data has its place, but there's also something to be said for personal opinion. That's why each year, we ask a few questions to try and get a feel for the pulse of the JavaScript developer community. 

--- a/surveys/2018/website/src/translations/hu-HU/introductions/other-tools-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/other-tools-introduction.md
@@ -1,0 +1,8 @@
+---
+type: introduction
+section: other-tools
+locale: en-US
+---
+ The JavaScript ecosystem isn't only limited to libraries and frameworks. There're all these small utilities we are using every day, including bundlers for code packaging and text editors for writing our code.
+
+In addition, we also wanted to know which new browser APIs were gaining traction; and yes, as crazy as it might sound it turns out some of us also use languages that *aren’t* JavaScript! 

--- a/surveys/2018/website/src/translations/hu-HU/introductions/other-tools-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/other-tools-introduction.md
@@ -1,7 +1,7 @@
 ---
 type: introduction
 section: other-tools
-locale: en-US
+locale: hu-HU
 ---
  The JavaScript ecosystem isn't only limited to libraries and frameworks. There're all these small utilities we are using every day, including bundlers for code packaging and text editors for writing our code.
 

--- a/surveys/2018/website/src/translations/hu-HU/introductions/support.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/support.md
@@ -1,0 +1,11 @@
+---
+type: introduction
+section: support_us
+locale: en-US
+---
+The State of JavaScript survey is a volunteer project, but in order to make the
+project sustainable we’re always looking for partners who can help support us,
+either financially or by helping us spread the word.
+
+If you think you could help in any way, please don’t hesitate to
+<a href="mailto:hello@stateofjs.com">get in touch</a>!

--- a/surveys/2018/website/src/translations/hu-HU/introductions/support.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/support.md
@@ -1,7 +1,7 @@
 ---
 type: introduction
 section: support_us
-locale: en-US
+locale: hu-HU
 ---
 The State of JavaScript survey is a volunteer project, but in order to make the
 project sustainable we’re always looking for partners who can help support us,

--- a/surveys/2018/website/src/translations/hu-HU/introductions/testing-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/testing-introduction.md
@@ -1,0 +1,7 @@
+---
+type: introduction
+section: testing
+locale: en-US
+---
+ Testing, testing… Is this thing on? Sorry, I Jest, but I would never want to make a Mocha-ry 
+of this section. That would be Jasmine (“just mean”? get it?), and that's bad Karma.

--- a/surveys/2018/website/src/translations/hu-HU/introductions/testing-introduction.md
+++ b/surveys/2018/website/src/translations/hu-HU/introductions/testing-introduction.md
@@ -1,7 +1,7 @@
 ---
 type: introduction
 section: testing
-locale: en-US
+locale: hu-HU
 ---
  Testing, testing… Is this thing on? Sorry, I Jest, but I would never want to make a Mocha-ry 
 of this section. That would be Jasmine (“just mean”? get it?), and that's bad Karma.


### PR DESCRIPTION
These modifications enable the built-in (but disabled) language selector in the 2018 survey site.
**DO NOT merge this PR**! This commit should NOT be part of the final PR that we send to the official repo when the translation is ready.