### PR TITLE
Correct preprocessor capitalization

### DIFF
--- a/typeform/surveys/2018css/outline.yaml
+++ b/typeform/surveys/2018css/outline.yaml
@@ -19,8 +19,8 @@
   template: tool
   id: preprocessors 
   questions:
-    - SASS
-    - LESS
+    - Sass
+    - Less
     - PostCSS
     - Stylus
     # - No Pre-/Post-processor


### PR DESCRIPTION
In their branding/sites, `Sass` & `Less` are both treated like plain title-case words, not all-caps acronyms.

* https://sass-lang.com/
* http://lesscss.org/