### PR TITLE
Introduces enhancements for translatable charts and fixes several errors for the es_ES translation

### DIFF
--- a/surveys/2018/website/src/core/components/Head.js
+++ b/surveys/2018/website/src/core/components/Head.js
@@ -11,8 +11,7 @@ const Head = () => (
                 {translate => {
                     const meta = getPageMeta(context, translate)
                     const socialMeta = getPageSocialMeta(context, translate)
-                    const description =
-                        'Discover the most popular JavaScript technologies of the year.'
+                    const description = translate(`meta.description`)
 
                     const mergedMeta = [
                         { charset: 'utf-8' },

--- a/surveys/2018/website/src/core/components/Nav.js
+++ b/surveys/2018/website/src/core/components/Nav.js
@@ -3,7 +3,7 @@ import nav from '../../../../config/enhanced_nav.yml'
 import { PageContextConsumer } from '../pages/pageContext'
 import PageLink from '../pages/PageLink'
 import PageLabel from '../pages/PageLabel'
-import LanguageSwitcher from '../i18n/LanguageSwitcher';
+import LanguageSwitcher from '../i18n/LanguageSwitcher'
 
 const filteredNav = nav.filter(page => !page.is_hidden)
 
@@ -51,7 +51,9 @@ const Nav = ({ closeSidebar }) => (
         {context => (
             <div className="nav">
                 <ul>
-                    <li><LanguageSwitcher/></li>
+                    <li>
+                        <LanguageSwitcher />
+                    </li>
                     {filteredNav.map((page, i) => (
                         <NavItem
                             key={i}

--- a/surveys/2018/website/src/core/components/Tooltip.js
+++ b/surveys/2018/website/src/core/components/Tooltip.js
@@ -2,8 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import Trans from 'core/i18n/Trans'
-import { libraryDescriptionToTranslationKey } from "core/i18n/translation-key-getters"
-import { translateOrFallback } from "core/i18n/translator"
+import { libraryDescriptionToTranslationKey } from 'core/i18n/translation-key-getters'
+import { translateOrFallback } from 'core/i18n/translator'
 
 const StarIcon = () => (
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
@@ -52,59 +52,60 @@ const Tooltip = ({ library, variant }) => {
 
     return (
         <Trans>
-            {
-                translate => (
-                    <div
-                        className={classNames(
-                            'Tooltip',
-                            'library__tooltip',
-                            { 'arrow-top': variant === 'horizontal' },
-                            { 'arrow-right': variant === 'vertical' }
-                        )}
-                    >
-                        <div className="toolip__topzone" />
-                        <div className="tooltip__inner">
-                            <h3 className="tooltip__title">
-                                <span className="tooltip__title__homepage">{library.name}</span>
-                                <a className="tooltip__title__stars" href={githubUrl}>
-                                    <StarTotal value={library.stars.toLocaleString()} />
-                                    <StarIcon />
-                                </a>
-                            </h3>
-                            <p className="tooltip__description">
-                                <Description text={translateOrFallback(
+            {translate => (
+                <div
+                    className={classNames(
+                        'Tooltip',
+                        'library__tooltip',
+                        { 'arrow-top': variant === 'horizontal' },
+                        { 'arrow-right': variant === 'vertical' }
+                    )}
+                >
+                    <div className="toolip__topzone" />
+                    <div className="tooltip__inner">
+                        <h3 className="tooltip__title">
+                            <span className="tooltip__title__homepage">{library.name}</span>
+                            <a className="tooltip__title__stars" href={githubUrl}>
+                                <StarTotal value={library.stars.toLocaleString()} />
+                                <StarIcon />
+                            </a>
+                        </h3>
+                        <p className="tooltip__description">
+                            <Description
+                                text={translateOrFallback(
                                     translate(libraryDescriptionToTranslationKey(library.name)),
                                     library.description
-                                )} showEmojis />
-                            </p>
-                            <h4>{translate("learn_more")}</h4>
-                            <ul>
-                                {library.homepage && (
-                                    <li>
-                                        <a className="Tooltip__Link" href={library.homepage}>
-                                            {translate("tool_homepage")}
-                                        </a>
-                                    </li>
                                 )}
-                                {githubUrl && (
-                                    <li>
-                                        <a className="Tooltip__Link" href={githubUrl}>
-                                            GitHub
-                                        </a>
-                                    </li>
-                                )}
-                                {bestofjsUrl && (
-                                    <li>
-                                        <a className="Tooltip__Link" href={bestofjsUrl}>
-                                            BestOfJS
-                                        </a>
-                                    </li>
-                                )}
-                            </ul>
-                        </div>
+                                showEmojis
+                            />
+                        </p>
+                        <h4>{translate('learn_more')}</h4>
+                        <ul>
+                            {library.homepage && (
+                                <li>
+                                    <a className="Tooltip__Link" href={library.homepage}>
+                                        {translate('tool_homepage')}
+                                    </a>
+                                </li>
+                            )}
+                            {githubUrl && (
+                                <li>
+                                    <a className="Tooltip__Link" href={githubUrl}>
+                                        GitHub
+                                    </a>
+                                </li>
+                            )}
+                            {bestofjsUrl && (
+                                <li>
+                                    <a className="Tooltip__Link" href={bestofjsUrl}>
+                                        BestOfJS
+                                    </a>
+                                </li>
+                            )}
+                        </ul>
                     </div>
-                )
-            }
+                </div>
+            )}
         </Trans>
     )
 }

--- a/surveys/2018/website/src/core/components/Tooltip.js
+++ b/surveys/2018/website/src/core/components/Tooltip.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
+import Trans from 'core/i18n/Trans'
+import { libraryDescriptionToTranslationKey } from "core/i18n/translation-key-getters"
+import { translateOrFallback } from "core/i18n/translator"
 
 const StarIcon = () => (
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
@@ -48,52 +51,61 @@ const Tooltip = ({ library, variant }) => {
     const bestofjsUrl = `https://bestofjs.org/projects/${library.slug}`
 
     return (
-        <div
-            className={classNames(
-                'Tooltip',
-                'library__tooltip',
-                { 'arrow-top': variant === 'horizontal' },
-                { 'arrow-right': variant === 'vertical' }
-            )}
-        >
-            <div className="toolip__topzone" />
-            <div className="tooltip__inner">
-                <h3 className="tooltip__title">
-                    <span className="tooltip__title__homepage">{library.name}</span>
-                    <a className="tooltip__title__stars" href={githubUrl}>
-                        <StarTotal value={library.stars.toLocaleString()} />
-                        <StarIcon />
-                    </a>
-                </h3>
-                <p className="tooltip__description">
-                    <Description text={library.description} showEmojis />
-                </p>
-                <h4>Learn More</h4>
-                <ul>
-                    {library.homepage && (
-                        <li>
-                            <a className="Tooltip__Link" href={library.homepage}>
-                                Homepage
-                            </a>
-                        </li>
-                    )}
-                    {githubUrl && (
-                        <li>
-                            <a className="Tooltip__Link" href={githubUrl}>
-                                GitHub
-                            </a>
-                        </li>
-                    )}
-                    {bestofjsUrl && (
-                        <li>
-                            <a className="Tooltip__Link" href={bestofjsUrl}>
-                                BestOfJS
-                            </a>
-                        </li>
-                    )}
-                </ul>
-            </div>
-        </div>
+        <Trans>
+            {
+                translate => (
+                    <div
+                        className={classNames(
+                            'Tooltip',
+                            'library__tooltip',
+                            { 'arrow-top': variant === 'horizontal' },
+                            { 'arrow-right': variant === 'vertical' }
+                        )}
+                    >
+                        <div className="toolip__topzone" />
+                        <div className="tooltip__inner">
+                            <h3 className="tooltip__title">
+                                <span className="tooltip__title__homepage">{library.name}</span>
+                                <a className="tooltip__title__stars" href={githubUrl}>
+                                    <StarTotal value={library.stars.toLocaleString()} />
+                                    <StarIcon />
+                                </a>
+                            </h3>
+                            <p className="tooltip__description">
+                                <Description text={translateOrFallback(
+                                    translate(libraryDescriptionToTranslationKey(library.name)),
+                                    library.description
+                                )} showEmojis />
+                            </p>
+                            <h4>{translate("learn_more")}</h4>
+                            <ul>
+                                {library.homepage && (
+                                    <li>
+                                        <a className="Tooltip__Link" href={library.homepage}>
+                                            {translate("tool_homepage")}
+                                        </a>
+                                    </li>
+                                )}
+                                {githubUrl && (
+                                    <li>
+                                        <a className="Tooltip__Link" href={githubUrl}>
+                                            GitHub
+                                        </a>
+                                    </li>
+                                )}
+                                {bestofjsUrl && (
+                                    <li>
+                                        <a className="Tooltip__Link" href={bestofjsUrl}>
+                                            BestOfJS
+                                        </a>
+                                    </li>
+                                )}
+                            </ul>
+                        </div>
+                    </div>
+                )
+            }
+        </Trans>
     )
 }
 

--- a/surveys/2018/website/src/core/i18n/Locales.js
+++ b/surveys/2018/website/src/core/i18n/Locales.js
@@ -19,7 +19,11 @@ const LangSelector = () => (
             return (
                 <div className="Locales">
                     {links.map(({ label, locale, link, isCurrent }) => (
-                        <Link className={`Locales__Item Locales__Item--${isCurrent && 'current'}`} key={locale} to={link}>
+                        <Link
+                            className={`Locales__Item Locales__Item--${isCurrent && 'current'}`}
+                            key={locale}
+                            to={link}
+                        >
                             {label}
                         </Link>
                     ))}

--- a/surveys/2018/website/src/core/i18n/country-name.js
+++ b/surveys/2018/website/src/core/i18n/country-name.js
@@ -1,1 +1,0 @@
-export const countryNameToTranslationKey = (name) => `countries.${name.replace(/ /g, "_").toLowerCase()}`;

--- a/surveys/2018/website/src/core/i18n/country-name.js
+++ b/surveys/2018/website/src/core/i18n/country-name.js
@@ -1,0 +1,1 @@
+export const countryNameToTranslationKey = (name) => `countries.${name.replace(/ /g, "_").toLowerCase()}`;

--- a/surveys/2018/website/src/core/i18n/gender-name.js
+++ b/surveys/2018/website/src/core/i18n/gender-name.js
@@ -1,1 +1,0 @@
-export const genderNameToTranslationKey = (name) => `genders.${name.replace(/ |-|\//g, "_").toLowerCase()}`;

--- a/surveys/2018/website/src/core/i18n/gender-name.js
+++ b/surveys/2018/website/src/core/i18n/gender-name.js
@@ -1,0 +1,1 @@
+export const genderNameToTranslationKey = (name) => `genders.${name.replace(/ /g, "_").toLowerCase()}`;

--- a/surveys/2018/website/src/core/i18n/gender-name.js
+++ b/surveys/2018/website/src/core/i18n/gender-name.js
@@ -1,1 +1,1 @@
-export const genderNameToTranslationKey = (name) => `genders.${name.replace(/ /g, "_").toLowerCase()}`;
+export const genderNameToTranslationKey = (name) => `genders.${name.replace(/ |-|\//g, "_").toLowerCase()}`;

--- a/surveys/2018/website/src/core/i18n/translation-key-getters.js
+++ b/surveys/2018/website/src/core/i18n/translation-key-getters.js
@@ -5,3 +5,5 @@ export const countryNameToTranslationKey = (name) => `countries.${keyFrom(name)}
 export const genderNameToTranslationKey = (name) => `genders.${keyFrom(name)}`
 
 export const sourceNameToTranslationKey = (name) => `sources.${keyFrom(name)}`
+
+export const libraryDescriptionToTranslationKey = (name) => `library.descriptions.${keyFrom(name)}`

--- a/surveys/2018/website/src/core/i18n/translation-key-getters.js
+++ b/surveys/2018/website/src/core/i18n/translation-key-getters.js
@@ -1,0 +1,7 @@
+const keyFrom = (name) => name.replace(/ |-|\//g, "_").toLowerCase()
+
+export const countryNameToTranslationKey = (name) => `countries.${keyFrom(name)}`
+
+export const genderNameToTranslationKey = (name) => `genders.${keyFrom(name)}`
+
+export const sourceNameToTranslationKey = (name) => `sources.${keyFrom(name)}`

--- a/surveys/2018/website/src/core/i18n/translation-key-getters.js
+++ b/surveys/2018/website/src/core/i18n/translation-key-getters.js
@@ -1,4 +1,4 @@
-const keyFrom = (name) => name.replace(/ |-|\//g, "_").toLowerCase()
+const keyFrom = (name) => name.replace(/ |-|\/|\./g, "_").toLowerCase()
 
 export const countryNameToTranslationKey = (name) => `countries.${keyFrom(name)}`
 

--- a/surveys/2018/website/src/core/i18n/translation-key-getters.js
+++ b/surveys/2018/website/src/core/i18n/translation-key-getters.js
@@ -1,9 +1,9 @@
-const keyFrom = (name) => name.replace(/ |-|\/|\./g, "_").toLowerCase()
+const keyFrom = name => name.replace(/ |-|\/|\./g, '_').toLowerCase()
 
-export const countryNameToTranslationKey = (name) => `countries.${keyFrom(name)}`
+export const countryNameToTranslationKey = name => `countries.${keyFrom(name)}`
 
-export const genderNameToTranslationKey = (name) => `genders.${keyFrom(name)}`
+export const genderNameToTranslationKey = name => `genders.${keyFrom(name)}`
 
-export const sourceNameToTranslationKey = (name) => `sources.${keyFrom(name)}`
+export const sourceNameToTranslationKey = name => `sources.${keyFrom(name)}`
 
-export const libraryDescriptionToTranslationKey = (name) => `library.descriptions.${keyFrom(name)}`
+export const libraryDescriptionToTranslationKey = name => `library.descriptions.${keyFrom(name)}`

--- a/surveys/2018/website/src/core/i18n/translator.js
+++ b/surveys/2018/website/src/core/i18n/translator.js
@@ -18,4 +18,4 @@ export const getTranslator = ({ locale, translations }) => (key, { values } = {}
 }
 
 export const translateOrFallback = (translatedKey, fallback) =>
-  translatedKey.match(/\[[a-z]{2}-[A-Z]{2}?\] [a-z_\-.]+/) ? fallback : translatedKey;
+    translatedKey.match(/\[[a-z]{2}-[A-Z]{2}?\] [a-z_\-.]+/) ? fallback : translatedKey

--- a/surveys/2018/website/src/core/i18n/translator.js
+++ b/surveys/2018/website/src/core/i18n/translator.js
@@ -16,3 +16,6 @@ export const getTranslator = ({ locale, translations }) => (key, { values } = {}
         return `[${locale}][ERR] ${key}`
     }
 }
+
+export const translateOrFallback = (translatedKey, fallback) =>
+  translatedKey.match(/\[[a-z]{2}-[A-Z]{2}?\] [a-z_\-.]+/) ? fallback : translatedKey;

--- a/surveys/2018/website/src/core/pages/Pagination.js
+++ b/surveys/2018/website/src/core/pages/Pagination.js
@@ -67,7 +67,7 @@ class Pagination extends React.PureComponent {
                                                 </button>
                                             </span>
                                         )}
-                                        <LanguageSwitcher/>
+                                        <LanguageSwitcher />
                                     </div>
                                     {next}
                                 </div>

--- a/surveys/2018/website/src/modules/demographics/charts/GenderBreakdownWaffleChart.js
+++ b/surveys/2018/website/src/modules/demographics/charts/GenderBreakdownWaffleChart.js
@@ -15,16 +15,24 @@ export default class GenderBreakdownWaffleChart extends Component {
 
         let total = 0
         const colors = []
-        const chartData = (translate) => data.filter(d => d.gender !== 'prefer not to say').map(d => {
-            colors.push(theme.genderColors[d.gender])
-            total += d.count
+        const chartData = (translate) => {
+            const result = data.filter(d => d.gender !== 'prefer not to say').map(d => {
+                colors.push(theme.genderColors[d.gender])
+                total += d.count
 
-            return {
-                id: d.gender,
-                label: translate(genderNameToTranslationKey(d.gender)) || d.gender,
-                value: d.count
-            }
-        })
+                const gender = translate(genderNameToTranslationKey(d.gender)) || d.gender
+
+                return {
+                    id: d.gender,
+                    label: gender,
+                    value: d.count
+                }
+            })
+
+            console.log("CHART DATA FOR GENDER BREAKDOWN", total);
+
+            return result;
+        }
 
         return (
             <Fragment>
@@ -32,17 +40,22 @@ export default class GenderBreakdownWaffleChart extends Component {
                 <div className="GenderBreakdown__Chart">
                     <ChartRatioContainer ratio={rows / columns} maxHeight={260}>
                         <Trans>
-                            {translate => (
-                                <ResponsiveWaffleCanvas
-                                    total={total}
-                                    rows={rows}
-                                    columns={columns}
-                                    data={chartData(translate)}
-                                    fillDirection="left"
-                                    theme={theme}
-                                    colors={colors}
-                                />
-                            )}
+                            {
+                                translate => {
+                                    const data = chartData(translate);
+                                    return (
+                                        <ResponsiveWaffleCanvas
+                                            total={total}
+                                            rows={rows}
+                                            columns={columns}
+                                            data={data}
+                                            fillDirection="left"
+                                            theme={theme}
+                                            colors={colors}
+                                        />
+                                    )
+                                }
+                            }
                         </Trans>
                     </ChartRatioContainer>
                 </div>

--- a/surveys/2018/website/src/modules/demographics/charts/GenderBreakdownWaffleChart.js
+++ b/surveys/2018/website/src/modules/demographics/charts/GenderBreakdownWaffleChart.js
@@ -4,7 +4,7 @@ import theme from 'nivoTheme'
 import ChartRatioContainer from 'core/charts/ChartRatioContainer'
 import GenderLegends from './GendersLegends'
 import Trans from 'core/i18n/Trans'
-import { genderNameToTranslationKey } from "core/i18n/gender-name"
+import { genderNameToTranslationKey } from "core/i18n/translation-key-getters"
 
 const rows = 32
 const columns = 128

--- a/surveys/2018/website/src/modules/demographics/charts/GenderBreakdownWaffleChart.js
+++ b/surveys/2018/website/src/modules/demographics/charts/GenderBreakdownWaffleChart.js
@@ -4,7 +4,7 @@ import theme from 'nivoTheme'
 import ChartRatioContainer from 'core/charts/ChartRatioContainer'
 import GenderLegends from './GendersLegends'
 import Trans from 'core/i18n/Trans'
-import { genderNameToTranslationKey } from "core/i18n/translation-key-getters"
+import { genderNameToTranslationKey } from 'core/i18n/translation-key-getters'
 
 const rows = 32
 const columns = 128
@@ -15,7 +15,7 @@ export default class GenderBreakdownWaffleChart extends Component {
 
         let total = 0
         const colors = []
-        const chartData = (translate) => {
+        const chartData = translate => {
             const result = data.filter(d => d.gender !== 'prefer not to say').map(d => {
                 colors.push(theme.genderColors[d.gender])
                 total += d.count
@@ -29,9 +29,9 @@ export default class GenderBreakdownWaffleChart extends Component {
                 }
             })
 
-            console.log("CHART DATA FOR GENDER BREAKDOWN", total);
+            console.log('CHART DATA FOR GENDER BREAKDOWN', total)
 
-            return result;
+            return result
         }
 
         return (
@@ -40,22 +40,20 @@ export default class GenderBreakdownWaffleChart extends Component {
                 <div className="GenderBreakdown__Chart">
                     <ChartRatioContainer ratio={rows / columns} maxHeight={260}>
                         <Trans>
-                            {
-                                translate => {
-                                    const data = chartData(translate);
-                                    return (
-                                        <ResponsiveWaffleCanvas
-                                            total={total}
-                                            rows={rows}
-                                            columns={columns}
-                                            data={data}
-                                            fillDirection="left"
-                                            theme={theme}
-                                            colors={colors}
-                                        />
-                                    )
-                                }
-                            }
+                            {translate => {
+                                const data = chartData(translate)
+                                return (
+                                    <ResponsiveWaffleCanvas
+                                        total={total}
+                                        rows={rows}
+                                        columns={columns}
+                                        data={data}
+                                        fillDirection="left"
+                                        theme={theme}
+                                        colors={colors}
+                                    />
+                                )
+                            }}
                         </Trans>
                     </ChartRatioContainer>
                 </div>

--- a/surveys/2018/website/src/modules/demographics/charts/GenderBreakdownWaffleChart.js
+++ b/surveys/2018/website/src/modules/demographics/charts/GenderBreakdownWaffleChart.js
@@ -3,6 +3,8 @@ import { ResponsiveWaffleCanvas } from '@nivo/waffle'
 import theme from 'nivoTheme'
 import ChartRatioContainer from 'core/charts/ChartRatioContainer'
 import GenderLegends from './GendersLegends'
+import Trans from 'core/i18n/Trans'
+import { genderNameToTranslationKey } from "core/i18n/gender-name"
 
 const rows = 32
 const columns = 128
@@ -13,13 +15,13 @@ export default class GenderBreakdownWaffleChart extends Component {
 
         let total = 0
         const colors = []
-        const chartData = data.filter(d => d.gender !== 'prefer not to say').map(d => {
+        const chartData = (translate) => data.filter(d => d.gender !== 'prefer not to say').map(d => {
             colors.push(theme.genderColors[d.gender])
             total += d.count
 
             return {
                 id: d.gender,
-                label: d.gender,
+                label: translate(genderNameToTranslationKey(d.gender)) || d.gender,
                 value: d.count
             }
         })
@@ -29,15 +31,19 @@ export default class GenderBreakdownWaffleChart extends Component {
                 <GenderLegends />
                 <div className="GenderBreakdown__Chart">
                     <ChartRatioContainer ratio={rows / columns} maxHeight={260}>
-                        <ResponsiveWaffleCanvas
-                            total={total}
-                            rows={rows}
-                            columns={columns}
-                            data={chartData}
-                            fillDirection="left"
-                            theme={theme}
-                            colors={colors}
-                        />
+                        <Trans>
+                            {translate => (
+                                <ResponsiveWaffleCanvas
+                                    total={total}
+                                    rows={rows}
+                                    columns={columns}
+                                    data={chartData(translate)}
+                                    fillDirection="left"
+                                    theme={theme}
+                                    colors={colors}
+                                />
+                            )}
+                        </Trans>
                     </ChartRatioContainer>
                 </div>
             </Fragment>

--- a/surveys/2018/website/src/modules/demographics/charts/GendersLegends.js
+++ b/surveys/2018/website/src/modules/demographics/charts/GendersLegends.js
@@ -2,12 +2,12 @@ import React from 'react'
 import theme from 'nivoTheme'
 import Legends from 'core/charts/Legends'
 import Trans from 'core/i18n/Trans'
-import { genderNameToTranslationKey } from "core/i18n/gender-name"
+import { genderNameToTranslationKey } from "core/i18n/translation-key-getters"
 
 
 const legends = (translate) => Object.keys(theme.genderColors).map(gender => ({
     id: gender,
-    label: translate(genderNameToTranslationKey(gender)) || gender,
+    label: translate(genderNameToTranslationKey(gender)),
     color: theme.genderColors[gender]
 }))
 

--- a/surveys/2018/website/src/modules/demographics/charts/GendersLegends.js
+++ b/surveys/2018/website/src/modules/demographics/charts/GendersLegends.js
@@ -1,13 +1,16 @@
 import React from 'react'
 import theme from 'nivoTheme'
 import Legends from 'core/charts/Legends'
+import Trans from 'core/i18n/Trans'
+import { genderNameToTranslationKey } from "core/i18n/gender-name"
 
-const legends = Object.keys(theme.genderColors).map(gender => ({
+
+const legends = (translate) => Object.keys(theme.genderColors).map(gender => ({
     id: gender,
-    label: gender,
+    label: translate(genderNameToTranslationKey(gender)) || gender,
     color: theme.genderColors[gender]
 }))
 
-const GenderLegends = () => <Legends legends={legends} modifier="horizontal" />
+const GenderLegends = () => <Trans>{translate => (<Legends legends={legends(translate)} modifier="horizontal" />)}</Trans>
 
 export default GenderLegends

--- a/surveys/2018/website/src/modules/demographics/charts/GendersLegends.js
+++ b/surveys/2018/website/src/modules/demographics/charts/GendersLegends.js
@@ -2,15 +2,17 @@ import React from 'react'
 import theme from 'nivoTheme'
 import Legends from 'core/charts/Legends'
 import Trans from 'core/i18n/Trans'
-import { genderNameToTranslationKey } from "core/i18n/translation-key-getters"
+import { genderNameToTranslationKey } from 'core/i18n/translation-key-getters'
 
+const legends = translate =>
+    Object.keys(theme.genderColors).map(gender => ({
+        id: gender,
+        label: translate(genderNameToTranslationKey(gender)),
+        color: theme.genderColors[gender]
+    }))
 
-const legends = (translate) => Object.keys(theme.genderColors).map(gender => ({
-    id: gender,
-    label: translate(genderNameToTranslationKey(gender)),
-    color: theme.genderColors[gender]
-}))
-
-const GenderLegends = () => <Trans>{translate => (<Legends legends={legends(translate)} modifier="horizontal" />)}</Trans>
+const GenderLegends = () => (
+    <Trans>{translate => <Legends legends={legends(translate)} modifier="horizontal" />}</Trans>
+)
 
 export default GenderLegends

--- a/surveys/2018/website/src/modules/demographics/charts/ParticipationByCountryMapChartTooltip.js
+++ b/surveys/2018/website/src/modules/demographics/charts/ParticipationByCountryMapChartTooltip.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import Trans from 'core/i18n/Trans'
-import { countryNameToTranslationKey } from "core/i18n/translation-key-getters";
+import { countryNameToTranslationKey } from 'core/i18n/translation-key-getters'
 
 const ParticipationByCountryMapChartTooltip = ({ feature: { properties, data } }) => (
     <Trans>

--- a/surveys/2018/website/src/modules/demographics/charts/ParticipationByCountryMapChartTooltip.js
+++ b/surveys/2018/website/src/modules/demographics/charts/ParticipationByCountryMapChartTooltip.js
@@ -1,12 +1,13 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import Trans from 'core/i18n/Trans'
+import { countryNameToTranslationKey } from "core/i18n/country-name";
 
 const ParticipationByCountryMapChartTooltip = ({ feature: { properties, data } }) => (
     <Trans>
         {translate => (
             <Fragment>
-                <strong>{properties.name}</strong>
+                <strong>{translate(countryNameToTranslationKey(properties.name)) || properties.name}</strong>
                 <br />
                 {data.percentage > 0 ? `${data.percentage}% - ` : ''}
                 {translate('users_count', { values: { count: data.count } })}

--- a/surveys/2018/website/src/modules/demographics/charts/ParticipationByCountryMapChartTooltip.js
+++ b/surveys/2018/website/src/modules/demographics/charts/ParticipationByCountryMapChartTooltip.js
@@ -1,13 +1,13 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import Trans from 'core/i18n/Trans'
-import { countryNameToTranslationKey } from "core/i18n/country-name";
+import { countryNameToTranslationKey } from "core/i18n/translation-key-getters";
 
 const ParticipationByCountryMapChartTooltip = ({ feature: { properties, data } }) => (
     <Trans>
         {translate => (
             <Fragment>
-                <strong>{translate(countryNameToTranslationKey(properties.name)) || properties.name}</strong>
+                <strong>{translate(countryNameToTranslationKey(properties.name))}</strong>
                 <br />
                 {data.percentage > 0 ? `${data.percentage}% - ` : ''}
                 {translate('users_count', { values: { count: data.count } })}

--- a/surveys/2018/website/src/modules/demographics/charts/SalaryPerCountryMapChartTooltip.js
+++ b/surveys/2018/website/src/modules/demographics/charts/SalaryPerCountryMapChartTooltip.js
@@ -1,11 +1,13 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import TransText from 'core/i18n/TransText'
-import { countryNameToTranslationKey } from "core/i18n/translation-key-getters";
+import { countryNameToTranslationKey } from 'core/i18n/translation-key-getters'
 
 const SalaryPerCountryMapChartTooltip = ({ feature: { properties, data } }) => (
     <Fragment>
-        <strong><TransText id={countryNameToTranslationKey(properties.name)} /></strong>
+        <strong>
+            <TransText id={countryNameToTranslationKey(properties.name)} />
+        </strong>
         <br />
         <TransText id="average" />:{' '}
         <strong>${data.salary.average.toFixed(3).replace('.', ',')}</strong>

--- a/surveys/2018/website/src/modules/demographics/charts/SalaryPerCountryMapChartTooltip.js
+++ b/surveys/2018/website/src/modules/demographics/charts/SalaryPerCountryMapChartTooltip.js
@@ -1,10 +1,11 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import TransText from 'core/i18n/TransText'
+import { countryNameToTranslationKey } from "core/i18n/translation-key-getters";
 
 const SalaryPerCountryMapChartTooltip = ({ feature: { properties, data } }) => (
     <Fragment>
-        <strong>{properties.name}</strong>
+        <strong><TransText id={countryNameToTranslationKey(properties.name)} /></strong>
         <br />
         <TransText id="average" />:{' '}
         <strong>${data.salary.average.toFixed(3).replace('.', ',')}</strong>

--- a/surveys/2018/website/src/modules/demographics/charts/SourceBreakdownWaffleChart.js
+++ b/surveys/2018/website/src/modules/demographics/charts/SourceBreakdownWaffleChart.js
@@ -15,16 +15,17 @@ export default class SourceBreakdownWaffleChart extends Component {
         console.log(data)
         let total = 0
         const colors = []
-        const chartData = (translate) => data.map(d => {
-            colors.push(theme.sourceColors[d.source])
-            total += d.count
+        const chartData = translate =>
+            data.map(d => {
+                colors.push(theme.sourceColors[d.source])
+                total += d.count
 
-            return {
-                id: d.source,
-                label: translate(sourceNameToTranslationKey(d.source)),
-                value: d.count
-            }
-        })
+                return {
+                    id: d.source,
+                    label: translate(sourceNameToTranslationKey(d.source)),
+                    value: d.count
+                }
+            })
 
         return (
             <Fragment>
@@ -32,23 +33,21 @@ export default class SourceBreakdownWaffleChart extends Component {
                 <div className="SourceBreakdown__Chart">
                     <ChartRatioContainer ratio={rows / columns} maxHeight={260}>
                         <Trans>
-                            {
-                                translate => {
-                                    const data = chartData(translate);
+                            {translate => {
+                                const data = chartData(translate)
 
-                                    return (                                
-                                        <ResponsiveWaffleCanvas
-                                            total={total}
-                                            rows={rows}
-                                            columns={columns}
-                                            data={data}
-                                            fillDirection="left"
-                                            theme={theme}
-                                            colors={colors}
-                                        />
-                                    )
-                                }
-                            }
+                                return (
+                                    <ResponsiveWaffleCanvas
+                                        total={total}
+                                        rows={rows}
+                                        columns={columns}
+                                        data={data}
+                                        fillDirection="left"
+                                        theme={theme}
+                                        colors={colors}
+                                    />
+                                )
+                            }}
                         </Trans>
                     </ChartRatioContainer>
                 </div>

--- a/surveys/2018/website/src/modules/demographics/charts/SourceBreakdownWaffleChart.js
+++ b/surveys/2018/website/src/modules/demographics/charts/SourceBreakdownWaffleChart.js
@@ -3,6 +3,8 @@ import { ResponsiveWaffleCanvas } from '@nivo/waffle'
 import theme from 'nivoTheme'
 import ChartRatioContainer from 'core/charts/ChartRatioContainer'
 import SourceLegends from './SourceLegends'
+import Trans from 'core/i18n/Trans'
+import { sourceNameToTranslationKey } from 'core/i18n/translation-key-getters'
 
 const rows = 32
 const columns = 128
@@ -13,13 +15,13 @@ export default class SourceBreakdownWaffleChart extends Component {
         console.log(data)
         let total = 0
         const colors = []
-        const chartData = data.map(d => {
+        const chartData = (translate) => data.map(d => {
             colors.push(theme.sourceColors[d.source])
             total += d.count
 
             return {
                 id: d.source,
-                label: d.source,
+                label: translate(sourceNameToTranslationKey(d.source)),
                 value: d.count
             }
         })
@@ -29,15 +31,25 @@ export default class SourceBreakdownWaffleChart extends Component {
                 <SourceLegends />
                 <div className="SourceBreakdown__Chart">
                     <ChartRatioContainer ratio={rows / columns} maxHeight={260}>
-                        <ResponsiveWaffleCanvas
-                            total={total}
-                            rows={rows}
-                            columns={columns}
-                            data={chartData}
-                            fillDirection="left"
-                            theme={theme}
-                            colors={colors}
-                        />
+                        <Trans>
+                            {
+                                translate => {
+                                    const data = chartData(translate);
+
+                                    return (                                
+                                        <ResponsiveWaffleCanvas
+                                            total={total}
+                                            rows={rows}
+                                            columns={columns}
+                                            data={data}
+                                            fillDirection="left"
+                                            theme={theme}
+                                            colors={colors}
+                                        />
+                                    )
+                                }
+                            }
+                        </Trans>
                     </ChartRatioContainer>
                 </div>
             </Fragment>

--- a/surveys/2018/website/src/modules/demographics/charts/SourceLegends.js
+++ b/surveys/2018/website/src/modules/demographics/charts/SourceLegends.js
@@ -4,12 +4,15 @@ import Legends from 'core/charts/Legends'
 import Trans from 'core/i18n/Trans'
 import { sourceNameToTranslationKey } from 'core/i18n/translation-key-getters'
 
-const legends = (translate) => Object.keys(theme.sourceColors).map(source => ({
-    id: source,
-    label: translate(sourceNameToTranslationKey(source)),
-    color: theme.sourceColors[source]
-}))
+const legends = translate =>
+    Object.keys(theme.sourceColors).map(source => ({
+        id: source,
+        label: translate(sourceNameToTranslationKey(source)),
+        color: theme.sourceColors[source]
+    }))
 
-const SourceLegends = () => <Trans>{translate => (<Legends legends={legends(translate)} modifier="horizontal" />)}</Trans>
+const SourceLegends = () => (
+    <Trans>{translate => <Legends legends={legends(translate)} modifier="horizontal" />}</Trans>
+)
 
 export default SourceLegends

--- a/surveys/2018/website/src/modules/demographics/charts/SourceLegends.js
+++ b/surveys/2018/website/src/modules/demographics/charts/SourceLegends.js
@@ -1,13 +1,15 @@
 import React from 'react'
 import theme from 'nivoTheme'
 import Legends from 'core/charts/Legends'
+import Trans from 'core/i18n/Trans'
+import { sourceNameToTranslationKey } from 'core/i18n/translation-key-getters'
 
-const legends = Object.keys(theme.sourceColors).map(source => ({
+const legends = (translate) => Object.keys(theme.sourceColors).map(source => ({
     id: source,
-    label: source,
+    label: translate(sourceNameToTranslationKey(source)),
     color: theme.sourceColors[source]
 }))
 
-const SourceLegends = () => <Legends legends={legends} modifier="horizontal" />
+const SourceLegends = () => <Trans>{translate => (<Legends legends={legends(translate)} modifier="horizontal" />)}</Trans>
 
 export default SourceLegends

--- a/surveys/2018/website/src/modules/sections/SectionIntroductionTemplate.js
+++ b/surveys/2018/website/src/modules/sections/SectionIntroductionTemplate.js
@@ -48,7 +48,9 @@ const SectionIntroductionTemplate = ({ pageContext, data: { introduction, sectio
                                 aggsType="years_of_experience"
                                 chartId="tools-years-of-experience"
                                 keys={yearsOfExperience}
-                                formatValue={v => `${v}${translateOrFallback(translate("years_short"), "yrs")}`}
+                                formatValue={v =>
+                                    `${v}${translateOrFallback(translate('years_short'), 'yrs')}`
+                                }
                                 data={section.usage_users_info.by_years_of_experience}
                             />
                             <HappinessBlock

--- a/surveys/2018/website/src/modules/sections/SectionIntroductionTemplate.js
+++ b/surveys/2018/website/src/modules/sections/SectionIntroductionTemplate.js
@@ -5,6 +5,7 @@ import { salaryRanges, companySizes, yearsOfExperience } from '../../constants'
 import Layout from 'core/Layout'
 import PageHeader from 'core/pages/PageHeader'
 import Trans from 'core/i18n/Trans'
+import { translateOrFallback } from 'core/i18n/translator'
 import OverviewBlock from './blocks/OverviewBlock'
 import HappinessBlock from './blocks/HappinessBlock'
 import ToolsSubAggsDistributionBlock from './blocks/ToolsSubAggsDistributionBlock'
@@ -47,7 +48,7 @@ const SectionIntroductionTemplate = ({ pageContext, data: { introduction, sectio
                                 aggsType="years_of_experience"
                                 chartId="tools-years-of-experience"
                                 keys={yearsOfExperience}
-                                formatValue={v => `${v}yrs`}
+                                formatValue={v => `${v}${translateOrFallback(translate("years_short"), "yrs")}`}
                                 data={section.usage_users_info.by_years_of_experience}
                             />
                             <HappinessBlock

--- a/surveys/2018/website/src/modules/sections/charts/OverviewChart.js
+++ b/surveys/2018/website/src/modules/sections/charts/OverviewChart.js
@@ -97,104 +97,114 @@ export default class OverviewChart extends Component {
 
         return (
             <PageContextConsumer>
-        {pageContext => (
-            <Trans>
-                {translate => (
-                    <div className="Overview__Chart">
-                        <ChartContainer height={360}>
-                            <ResponsiveBar
-                                margin={margin}
-                                keys={[
-                                    'would_use',
-                                    'would_not_use',
-                                    'interested',
-                                    'not_interested',
-                                    'never_heard'
-                                ]}
-                                indexBy="tool_id"
-                                data={sortedData}
-                                theme={theme}
-                                colorBy={this.getColor}
-                                labelFormat={format}
-                                tooltipFormat={format}
-                                labelTextColor="inherit:darker(2)"
-                                labelSkipWidth={32}
-                                labelSkipHeight={20}
-                                padding={0.6}
-                                axisLeft={null}
-                                enableGridY={false}
-                                axisTop={{
-                                    renderTick: tick => (
-                                        <g
-                                            key={tick.key}
-                                            transform={`translate(${tick.x - 30},${tick.y - 80})`}
-                                        >
-                                            <PeriodicElement
-                                                mode="chart"
-                                                section={section}
-                                                tool={tick.value}
-                                                symbol={periodicTableData.tools[tick.value] || '??'}
-                                                name={getToolName(tick.value, translate)}
-                                                size={60}
-                                                number={ranking[tick.value]}
-                                                path={`${pageContext.localePath}/${section}/${tick.value}`}
-                                            />
-                                        </g>
-                                    )
-                                }}
-                                axisBottom={{
-                                    tickSize: 0,
-                                    tickPadding: 10,
-                                    renderTick: tick => (
-                                        <g
-                                            key={tick.key}
-                                            transform={`translate(${tick.x},${tick.y + 14})`}
-                                            style={{ cursor: 'pointer' }}
-                                            onClick={() => {
-                                                navigate(`${section}/${tick.value}`)
-                                            }}
-                                        >
-                                            <text
-                                                fill="#41c7c7"
-                                                textAnchor="middle"
-                                                alignmentBaseline="hanging"
-                                                style={{ fontSize: '13px' }}
-                                            >
-                                                {getToolName(tick.value, translate)}
-                                            </text>
-                                        </g>
-                                    )
-                                }}
-                                defs={patterns}
-                                fill={[
-                                    {
-                                        match: {
-                                            id: 'never_heard'
-                                        },
-                                        id: 'lines'
-                                    }
-                                ]}
-                                tooltipLabel={d => translate(`opinions.legends_short.${d.id}`)}
-                            />
-                        </ChartContainer>
-                        <div>
-                            <div className="Overview__Chart__SwitchContainer">
-                                <DisplayModeSwitch
-                                    mode={displayMode}
-                                    onChange={this.setDisplayMode}
-                                />
+                {pageContext => (
+                    <Trans>
+                        {translate => (
+                            <div className="Overview__Chart">
+                                <ChartContainer height={360}>
+                                    <ResponsiveBar
+                                        margin={margin}
+                                        keys={[
+                                            'would_use',
+                                            'would_not_use',
+                                            'interested',
+                                            'not_interested',
+                                            'never_heard'
+                                        ]}
+                                        indexBy="tool_id"
+                                        data={sortedData}
+                                        theme={theme}
+                                        colorBy={this.getColor}
+                                        labelFormat={format}
+                                        tooltipFormat={format}
+                                        labelTextColor="inherit:darker(2)"
+                                        labelSkipWidth={32}
+                                        labelSkipHeight={20}
+                                        padding={0.6}
+                                        axisLeft={null}
+                                        enableGridY={false}
+                                        axisTop={{
+                                            renderTick: tick => (
+                                                <g
+                                                    key={tick.key}
+                                                    transform={`translate(${tick.x - 30},${tick.y -
+                                                        80})`}
+                                                >
+                                                    <PeriodicElement
+                                                        mode="chart"
+                                                        section={section}
+                                                        tool={tick.value}
+                                                        symbol={
+                                                            periodicTableData.tools[tick.value] ||
+                                                            '??'
+                                                        }
+                                                        name={getToolName(tick.value, translate)}
+                                                        size={60}
+                                                        number={ranking[tick.value]}
+                                                        path={`${
+                                                            pageContext.localePath
+                                                        }/${section}/${tick.value}`}
+                                                    />
+                                                </g>
+                                            )
+                                        }}
+                                        axisBottom={{
+                                            tickSize: 0,
+                                            tickPadding: 10,
+                                            renderTick: tick => (
+                                                <g
+                                                    key={tick.key}
+                                                    transform={`translate(${tick.x},${tick.y +
+                                                        14})`}
+                                                    style={{ cursor: 'pointer' }}
+                                                    onClick={() => {
+                                                        navigate(`${section}/${tick.value}`)
+                                                    }}
+                                                >
+                                                    <text
+                                                        fill="#41c7c7"
+                                                        textAnchor="middle"
+                                                        alignmentBaseline="hanging"
+                                                        style={{ fontSize: '13px' }}
+                                                    >
+                                                        {getToolName(tick.value, translate)}
+                                                    </text>
+                                                </g>
+                                            )
+                                        }}
+                                        defs={patterns}
+                                        fill={[
+                                            {
+                                                match: {
+                                                    id: 'never_heard'
+                                                },
+                                                id: 'lines'
+                                            }
+                                        ]}
+                                        tooltipLabel={d =>
+                                            translate(`opinions.legends_short.${d.id}`)
+                                        }
+                                    />
+                                </ChartContainer>
+                                <div>
+                                    <div className="Overview__Chart__SwitchContainer">
+                                        <DisplayModeSwitch
+                                            mode={displayMode}
+                                            onChange={this.setDisplayMode}
+                                        />
+                                    </div>
+                                    <OpinionsLegends
+                                        layout="vertical"
+                                        withFrame={false}
+                                        onMouseEnter={this.setCurrent}
+                                        onMouseLeave={this.resetCurrent}
+                                    />
+                                </div>
                             </div>
-                            <OpinionsLegends
-                                layout="vertical"
-                                withFrame={false}
-                                onMouseEnter={this.setCurrent}
-                                onMouseLeave={this.resetCurrent}
-                            />
-                        </div>
-                    </div>
+                        )}
+                    </Trans>
                 )}
-            </Trans>)}
-    </PageContextConsumer>
+            </PageContextConsumer>
         )
     }
 }

--- a/surveys/2018/website/src/modules/tools/blocks/ToolHeaderBlock.js
+++ b/surveys/2018/website/src/modules/tools/blocks/ToolHeaderBlock.js
@@ -6,6 +6,8 @@ import periodicTableData from 'data/periodic_table.yml'
 import ranking from 'data/results/tools_ranking.yml'
 import PeriodicElement from 'core/components/PeriodicElement'
 import Trans from 'core/i18n/Trans'
+import { translateOrFallback } from 'core/i18n/translator'
+import { libraryDescriptionToTranslationKey } from 'core/i18n/translation-key-getters'
 import { getToolName } from 'core/helpers/tools'
 
 const starsFormatter = format('.2s')
@@ -42,12 +44,12 @@ export default class ToolHeaderBlock extends Component {
                                     <h2 className="ToolHeader__Title">{toolName}</h2>
                                     {project.stars && (
                                         <div className="ToolHeader__Stars">
-                                            {starsFormatter(project.stars)} stars
+                                            {starsFormatter(project.stars)} {translateOrFallback(translate("github_stars"), "stars")}
                                         </div>
                                     )}
                                 </div>
                                 <Fragment>
-                                    <div>{project.description}</div>
+                                    <div>{translateOrFallback(translate(libraryDescriptionToTranslationKey(toolName)), project.description)}</div>
                                     <div className="ToolHeader__Links">
                                         {project.homepage && (
                                             <a

--- a/surveys/2018/website/src/modules/tools/blocks/ToolHeaderBlock.js
+++ b/surveys/2018/website/src/modules/tools/blocks/ToolHeaderBlock.js
@@ -44,12 +44,21 @@ export default class ToolHeaderBlock extends Component {
                                     <h2 className="ToolHeader__Title">{toolName}</h2>
                                     {project.stars && (
                                         <div className="ToolHeader__Stars">
-                                            {starsFormatter(project.stars)} {translateOrFallback(translate("github_stars"), "stars")}
+                                            {starsFormatter(project.stars)}{' '}
+                                            {translateOrFallback(
+                                                translate('github_stars'),
+                                                'stars'
+                                            )}
                                         </div>
                                     )}
                                 </div>
                                 <Fragment>
-                                    <div>{translateOrFallback(translate(libraryDescriptionToTranslationKey(toolName)), project.description)}</div>
+                                    <div>
+                                        {translateOrFallback(
+                                            translate(libraryDescriptionToTranslationKey(toolName)),
+                                            project.description
+                                        )}
+                                    </div>
                                     <div className="ToolHeader__Links">
                                         {project.homepage && (
                                             <a

--- a/surveys/2018/website/src/modules/tools/charts/ToolUsageByCountryMapChartTooltip.js
+++ b/surveys/2018/website/src/modules/tools/charts/ToolUsageByCountryMapChartTooltip.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import Trans from 'core/i18n/Trans'
-import { countryNameToTranslationKey } from "core/i18n/translation-key-getters";
+import { countryNameToTranslationKey } from 'core/i18n/translation-key-getters'
 
 const ToolUsageByCountryMapChartTooltip = ({
     feature: {

--- a/surveys/2018/website/src/modules/tools/charts/ToolUsageByCountryMapChartTooltip.js
+++ b/surveys/2018/website/src/modules/tools/charts/ToolUsageByCountryMapChartTooltip.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import Trans from 'core/i18n/Trans'
+import { countryNameToTranslationKey } from "core/i18n/translation-key-getters";
 
 const ToolUsageByCountryMapChartTooltip = ({
     feature: {
@@ -11,7 +12,7 @@ const ToolUsageByCountryMapChartTooltip = ({
     <Trans>
         {translate => (
             <Fragment>
-                <strong>{properties.name}</strong>
+                <strong>{translate(countryNameToTranslationKey(properties.name))}</strong>
                 <br />
                 {translate('users_count', { values: { count } })}
                 <br />

--- a/surveys/2018/website/src/pages/index.js
+++ b/surveys/2018/website/src/pages/index.js
@@ -5,7 +5,7 @@ import Animation from 'core/components/Animation'
 import { PageContextProvider } from 'core/pages/pageContext'
 import { mergePageContext } from 'core/pages/pageHelpers'
 import { I18nContextProvider } from 'core/i18n/i18nContext'
-import LanguageSwitcher from '../core/i18n/LanguageSwitcher';
+import LanguageSwitcher from '../core/i18n/LanguageSwitcher'
 
 const Home = ({ pageContext, location }) => {
     const context = mergePageContext(pageContext, location)
@@ -17,7 +17,7 @@ const Home = ({ pageContext, location }) => {
                     <Head />
                     <div className="Home__Wrapper">
                         <Animation />
-                        <LanguageSwitcher position="top"/>
+                        <LanguageSwitcher position="top" />
                     </div>
                 </Fragment>
             </I18nContextProvider>

--- a/surveys/2018/website/src/stylesheets/_animation.scss
+++ b/surveys/2018/website/src/stylesheets/_animation.scss
@@ -1,7 +1,7 @@
 .Home__Wrapper {
     height: 100vh;
     display: grid;
-    grid-template-rows: 1fr auto; 
+    grid-template-rows: 1fr auto;
 }
 .LogoAnimation__Wrapper {
     height: 100%;

--- a/surveys/2018/website/src/stylesheets/_languages.scss
+++ b/surveys/2018/website/src/stylesheets/_languages.scss
@@ -6,7 +6,7 @@
         }
     }
     .nav & {
-        @include large{
+        @include large {
             display: none;
         }
     }
@@ -15,7 +15,7 @@
     }
 }
 
-.LanguageSwitcher__Inner{
+.LanguageSwitcher__Inner {
     position: relative;
 }
 
@@ -82,8 +82,7 @@
         margin-left: -11px;
     }
     .LanguageSwitcher--bottom & {
-
-    top: 130%;
+        top: 130%;
         &:after,
         &:before {
             bottom: 100%;
@@ -126,7 +125,7 @@
     @include large {
         font-size: $medium-font;
     }
-    &--current{
+    &--current {
         @include font-bold;
     }
 }

--- a/surveys/2018/website/src/stylesheets/_pagetitle.scss
+++ b/surveys/2018/website/src/stylesheets/_pagetitle.scss
@@ -2,6 +2,9 @@
     border-top: 1px solid $dark-border-color;
     border-bottom: 1px solid $dark-border-color;
 
+    // Fixes overlap with <Tooltip />
+    z-index: 0;
+
     // background: $light-bg-color;
 }
 

--- a/surveys/2018/website/src/stylesheets/_pagetitle.scss
+++ b/surveys/2018/website/src/stylesheets/_pagetitle.scss
@@ -52,7 +52,7 @@
     }
 }
 
-.pagination__middle{
+.pagination__middle {
     @include flex-center;
     span + & {
         border-left: 1px solid $dark-border-color;

--- a/surveys/2018/website/src/translations/en-US.yml
+++ b/surveys/2018/website/src/translations/en-US.yml
@@ -768,3 +768,7 @@ translations:
       t: State Of JavaScript Survey Results
     - key: share.block.body
       t: 'Here are some interesting JavaScript survey results (${title}): ${link}'
+
+    # meta
+    - key: meta.description
+      t: Discover the most popular JavaScript technologies of the year.

--- a/surveys/2018/website/src/translations/en-US.yml
+++ b/surveys/2018/website/src/translations/en-US.yml
@@ -340,6 +340,8 @@ translations:
       t: Haxe
 
     # pages
+    - key: page.home
+      t: Home
     - key: page.introduction
       t: Introduction
     - key: page.demographics

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -326,6 +326,12 @@ translations:
       t: Web Audio API
     - key: tool.web-speech-api
       t: Web Speech API
+    - key: tool.dart
+      t: Dart
+    - key: tool.kotlin
+      t: Kotlin
+    - key: tool.haxe
+      t: Haxe
 
     # pages
     - key: page.home
@@ -619,7 +625,7 @@ translations:
     - key: reason.lacking_developer_tooling.long
       t: 🔧 Herramientas de desarrollo incompletas
     - key: reason.lacking_developer_tooling.short
-      t: 🔧 Herramientas incompletas
+      t: 🔧 Faltan herramientas
     - key: reason.bad_documentation.long
       t: 📖 Mala documentación
     - key: reason.bad_documentation.short
@@ -627,11 +633,11 @@ translations:
     - key: reason.concerns_about_the_team_company.long
       t: 👫 Preocupaciones por el equipo/organización
     - key: reason.concerns_about_the_team_company.short
-      t: 👫 Mal equipo/organización
+      t: 👫 Mal administración
     - key: reason.bloated_complex.long
       t: 🎈 Sobrecargada y compleja
     - key: reason.bloated_complex.short
-      t: 🎈 Sovrecargada y compleja
+      t: 🎈 Compleja de usar
     - key: reason.diminishing_momentum_popularity.long
       t: 📉 Popularidad e impulso decreciendo
     - key: reason.diminishing_momentum_popularity.short

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -768,6 +768,16 @@ translations:
     - key: meta.description
       t: Descubre las tecnologías de JavaScript más populares del año.
 
+    # genders
+    - key: genders.female
+      t: femenino
+    - key: genders.male
+      t: masculino
+    - key: genders.non_binary__third_gender
+      t: no-binario / tercer género
+    - key: genders.other
+      t: otro
+
     # countries
     - key: countries.usa
       t: Estados Unidos

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -763,3 +763,7 @@ translations:
       t: Resultados de la encuesta State Of JavaScript
     - key: share.block.body
       t: 'Aquí hay algunos resultados interesantes de la encuesta de JavaScript (${title}): ${link}'
+
+    # meta
+    - key: meta.description
+      t: Descubre las tecnologías de JavaScript más populares del año.

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -31,6 +31,8 @@ translations:
       t: Finalistas
     - key: tool_homepage
       t: Página principal
+    - key: learn_more
+      t: Aprende más
     - key: from_to_short
       t: ${from} a ${to}
     - key: users_count

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -47,6 +47,10 @@ translations:
       t: |
         Gracias a nuestros socios por apoyar este proyecto.
         <a href="/support">Aprender más</a> sobre cómo apoyar The State of JS.
+    - key: years_short
+      t: "años"
+    - key: github_stars
+      t: estrellas
 
     # opinions
     - key: opinions.legends.never_heard

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -770,13 +770,33 @@ translations:
 
     # genders
     - key: genders.female
-      t: femenino
+      t: Femenino
     - key: genders.male
-      t: masculino
+      t: Masculino
     - key: genders.non_binary__third_gender
-      t: no-binario / tercer género
+      t: No-binario / Tercer género
     - key: genders.other
-      t: otro
+      t: Otro
+
+    # sources
+    - key: sources.email
+      t: Correo electrónico
+    - key: sources.slack
+      t: Slack
+    - key: sources.medium
+      t: Medium
+    - key: sources.twitter
+      t: Twitter
+    - key: sources.javascript_weekly
+      t: JavaScript Weekly
+    - key: sources.facebook
+      t: Facebook
+    - key: sources.reddit
+      t: Reddit
+    - key: sources.hacker_news
+      t: Hacker News
+    - key: sources.other_unknown
+      t: Otras/Desconocida
 
     # countries
     - key: countries.usa

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -174,11 +174,11 @@ translations:
     - key: section.javascript-flavors
       t: Variantes de JS
     - key: section.front-end-frameworks
-      t: Frameworks de Front-end
+      t: "Frameworks: Front-end"
     - key: section.data-layer
       t: Capa de Datos
     - key: section.back-end-frameworks
-      t: Frameworks de Back-end 
+      t: "Frameworks: Back-end"
     - key: section.testing
       t: Testing
     - key: section.mobile-and-desktop

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -767,3 +767,143 @@ translations:
     # meta
     - key: meta.description
       t: Descubre las tecnologías de JavaScript más populares del año.
+
+    # countries
+    - key: countries.usa
+      t: Estados Unidos
+    - key: countries.canada
+      t: Canadá
+    - key: countries.mexico
+      t: México
+    - key: countries.panama
+      t: Panamá
+    - key: countries.haiti
+      t: Haití
+    - key: countries.france
+      t: Francia
+    - key: countries.brazil
+      t: Brasil
+    - key: countries.peru
+      t: Perú
+    - key: countries.morocco
+      t: Marruecos
+    - key: countries.algeria
+      t: Argelia
+    - key: countries.iceland
+      t: Islandia
+    - key: countries.ireland
+      t: Irlanda
+    - key: countries.uk
+      t: Reino Unido
+    - key: countries.spain
+      t: España
+    - key: countries.cameroon
+      t: Camerún
+    - key: countries.libya
+      t: Libia
+    - key: countries.tunisia
+      t: Túnez
+    - key: countries.egypt
+      t: Egipto
+    - key: countries.central_african_republic
+      t: República Centroafricana
+    - key: countries.south_sudan
+      t: Sudán del Sur
+    - key: countries.ethiopia
+      t: Etiopía
+    - key: countries.somalia
+      t: Somalía
+    - key: countries.kenya
+      t: Kenia
+    - key: countries.south_africa
+      t: Sudáfrica
+    - key: countries.italy
+      t: Italia
+    - key: countries.switzerland
+      t: Suiza
+    - key: countries.belgium
+      t: Bélgica
+    - key: countries.germany
+      t: Alemania
+    - key: countries.luxembourg
+      t: Luxemburgo
+    - key: countries.netherlands
+      t: Países Bajos
+    - key: countries.denmark
+      t: Dinamarca
+    - key: countries.norway
+      t: Noruega
+    - key: countries.sweden
+      t: Suecia
+    - key: countries.finland
+      t: Finlandia
+    - key: countries.russia
+      t: Rusia
+    - key: countries.belarus
+      t: Belarús
+    - key: countries.slovenia
+      t: Eslovenia
+    - key: countries.czech_republic
+      t: República Checa
+    - key: countries.poland
+      t: Polonia
+    - key: countries.slovakia
+      t: Eslovaquia
+    - key: countries.hungary
+      t: Hungría
+    - key: countries.romania
+      t: Rumania
+    - key: countries.bosnia_and_herzegovina
+      t: Bosnia y Herzegovina
+    - key: countries.croatia
+      t: Croacia
+    - key: countries.greece
+      t: Grecia
+    - key: countries.turkey
+      t: Turquía
+    - key: countries.ukraine
+      t: Ucrania
+    - key: countries.moldova
+      t: Moldavia
+    - key: countries.lithuania
+      t: Lituania
+    - key: countries.latvia
+      t: Letonia
+    - key: countries.azerbaijan
+      t: Azerbaiyán
+    - key: countries.jordan
+      t: Jordania
+    - key: countries.saudi_arabia
+      t: Arabia Saudita
+    - key: countries.united_arab_emirates
+      t: Emiratos Árabes Unidos
+    - key: countries.iran
+      t: Irán
+    - key: countries.afghanistan
+      t: Afganistán
+    - key: countries.uzbekistan
+      t: Uzbekistán
+    - key: countries.pakistan
+      t: Pakistán
+    - key: countries.kazakhstan
+      t: Kazakistán
+    - key: countires.kyrgyzstan
+      t: Kirguistán
+    - key: countries.thailand
+      t: Tailandia
+    - key: countries.cambodia
+      t: Camboya
+    - key: countries.malaysia
+      t: Malasia
+    - key: countries.philippines
+      t: Filipinas
+    - key: countries.new_zealand
+      t: Nueva Zelanda
+    - key: countries.new_caledonia
+      t: Nueva Caledonia
+    - key: countries.japan
+      t: Japón
+    - key: countries.korea
+      t: Corea
+    - key: countries.lebanon
+      t: Líbano

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -569,7 +569,7 @@ translations:
     - key: reason.powerful_developer_tooling.short
       t: 🔧 Herramientas
     - key: reason.good_documentation.long
-      t: 📖 Beuna documentación
+      t: 📖 Buena documentación
     - key: reason.good_documentation.short
       t: 📖 Documentación
     - key: reason.backed_by_a_great_team_company.long

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -541,9 +541,9 @@ translations:
 
     # reasons
     - key: reason.elegant_programming_style_patterns.long
-      t: ⚙️ Estilos de programación y patrones de desarollo elegantes
+      t: ⚙️ Paradigma y patrones de desarrollo elegantes
     - key: reason.elegant_programming_style_patterns.short
-      t: ⚙️ Estilo de programación
+      t: ⚙️ Paradigma elegante
     - key: reason.robust_less_error_prone_code.long
       t: 🐞 Código robusto, menos propenso a errores
     - key: reason.robust_less_error_prone_code.short
@@ -551,7 +551,7 @@ translations:
     - key: reason.rich_package_ecosystem.long
       t: 🎁 Ecosistema rico en paquetes
     - key: reason.rich_package_ecosystem.short  
-      t: 🎁 Ecosistema de paquetes
+      t: 🎁 Muchos paquetes
     - key: reason.fast_performance.long
       t: ⚡ Performance rápida
     - key: reason.fast_performance.short  
@@ -587,7 +587,7 @@ translations:
     - key: reason.full_featured_powerful.long
       t: 🕹️ Completa en funcionalidad y poderosa
     - key: reason.full_featured_powerful.short
-      t: 🕹️ Completa en funcionalidad
+      t: 🕹️ Funcional
     - key: reason.stable_backwards_compatible.long
       t: ⚖️ Estable y retrocompatible
     - key: reason.stable_backwards_compatible.short

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -897,7 +897,7 @@ translations:
       t: Pakistán
     - key: countries.kazakhstan
       t: Kazakistán
-    - key: countires.kyrgyzstan
+    - key: countries.kyrgyzstan
       t: Kirguistán
     - key: countries.thailand
       t: Tailandia
@@ -917,3 +917,107 @@ translations:
       t: Corea
     - key: countries.lebanon
       t: Líbano
+    - key: countries.argentina
+      t: Argentina
+    - key: countries.chile
+      t: Chile
+    - key: countries.uruguay
+      t: Uruguay
+    - key: countries.paraguay
+      t: Paraguay
+    - key: countries.ecuador
+      t: Ecuador
+    - key: countries.venezuela
+      t: Venezuela
+    - key: countries.bolivia
+      t: Bolivia
+    - key: countries.colombia
+      t: Colombia
+    - key: countries.costa_rica
+      t: Costa Rica
+    - key: countries.nicaragua
+      t: Nicaragua
+    - key: countries.honduras
+      t: Honduras
+    - key: countries.el_salvador
+      t: El Salvador
+    - key: countries.belize
+      t: Belice
+    - key: countries.guatemala
+      t: Guatemala
+    - key: countries.cuba
+      t: Cuba
+    - key: countries.dominican_republic
+      t: República Dominicana
+    - key: countries.puerto_rico
+      t: Puerto Rico
+    - key: countries.jamaica
+      t: Jamaica
+    - key: countries.senegal
+      t: Senegal
+    - key: countries.burkina_faso
+      t: Burkina Faso
+    - key: countries.ghana
+      t: Ghana
+    - key: countries.chad
+      t: Chad
+    - key: countries.nigeria
+      t: Nigeria
+    - key: countries.uganda
+      t: Uganda
+    - key: countries.tanzania
+      t: Tanzania
+    - key: countries.mozambique
+      t: Mozambique
+    - key: countries.zambia
+      t: Zambia
+    - key: countries.angola
+      t: Angola
+    - key: countries.zimbabwe
+      t: Zimbabwe
+    - key: countries.madagascar
+      t: Madagascar
+    - key: countries.serbia
+      t: Serbia
+    - key: countries.bulgaria
+      t: Bulgaria
+    - key: countries.china
+      t: China
+    - key: countries.nepal
+      t: Nepal
+    - key: countries.vietnam
+      t: Vietnam
+    - key: countries.australia
+      t: Australia
+    - key: countries.india
+      t: India
+    - key: countries.indonesia
+      t: Indonesia
+    - key: countries.myanmar
+      t: Myanmar
+    - key: countries.mongolia
+      t: Mongolia
+    - key: countries.iraq
+      t: Irak
+    - key: countries.austria
+      t: Austria
+    - key: countries.montenegro
+      t: Montenegro
+    - key: countries.albania
+      t: Albania
+    - key: countries.georgia
+      t: Georgia
+    - key: countries.sri_lanka
+      t: Sri Lanka
+    - key: countries.armenia
+      t: Armenia
+    - key: countries.cyprus
+      t: Chipre
+    - key: countries.israel
+      t: Israel
+    - key: countries.macedonia
+      t: Macedonia
+    - key: countries.portugal
+      t: Portugal
+    - key: countries.estonia
+      t: Estonia

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -172,7 +172,7 @@ translations:
 
     # sections
     - key: section.javascript-flavors
-      t: Variantes de JavaScript
+      t: Variantes de JS
     - key: section.front-end-frameworks
       t: Frameworks de Front-end
     - key: section.data-layer

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -328,6 +328,8 @@ translations:
       t: Web Speech API
 
     # pages
+    - key: page.home
+      t: Inicio
     - key: page.introduction
       t: Introducción
     - key: page.demographics

--- a/surveys/2018/website/src/translations/es-ES.yml
+++ b/surveys/2018/website/src/translations/es-ES.yml
@@ -1049,3 +1049,251 @@ translations:
       t: Portugal
     - key: countries.estonia
       t: Estonia
+
+    # tool descriptions (see bestof.json)
+    - key: library.descriptions.typescript
+      t: TypeScript es una extensión de JavaScript que compila a JavaScript puro.
+    - key: library.descriptions.flow
+      t: Agrega tipos estáticos a JavaScript para mejorar la productividad y la calidad del código en el desarrollo.
+    - key: library.descriptions.elm
+      t: Compilador para Elm, un lenguaje funcional para aplicaciones web confiables.
+    - key: library.descriptions.clojurescript
+      t: Compilador de JS a Clojure.
+    - key: library.descriptions.reason
+      t: Código tipado, simple y rápido que se nutre de los ecosistemas de JavaScript y OCaml.
+    - key: library.descriptions.purescript
+      t: Un lenguaje fuertamente tipado que compila a JavaScript.
+    - key: library.descriptions.coffeescript
+      t: Un pequeño lenguaje que compila a JavaScript.
+    - key: library.descriptions.react
+      t: Una librería de JavaScript, flexible, declarativa y eficiente para construir interfaces de usuario.
+    - key: library.descriptions.angular_1
+      t: "AngularJS: ¡HTML mejorado para aplicaciones web!"
+    - key: library.descriptions.ember
+      t: "Ember.js, un framework de JavaScript para crear aplicaciones web ambiciosas."
+    - key: library.descriptions.vue_js
+      t: "🖖 Un framework de JavaScript, progresivo e incrementalmente adoptable para construir interfaces de usuario en la Web."
+    - key: library.descriptions.backbone
+      t: Dale a tus aplicaciones JavaScript un esqueleto con modelos, vistas, colecciones y eventos.
+    - key: library.descriptions.polymer
+      t: La librería original para Web Components.
+    - key: library.descriptions.aurelia
+      t: El framework de Aurelia une todas las librerías principales de Aurelia en una plataforma de construcción de aplicaciones lista para usar.
+    - key: library.descriptions.preact
+      t: ⚛️ Una alternativa rápida y de 3kb a React, con la misma API moderna. Componentes y Virtual DOM.
+    - key: library.descriptions.knockout
+      t: Knockout hace más fácil la creación de interfaces de usuario responsivas con JavaScript.
+    - key: library.descriptions.jquery
+      t: La librería jQuery para JavaScript.
+    - key: library.descriptions.cycle_js
+      t: Un framework reactivo y funcional para escribir código predecible en JavaScript.
+    - key: library.descriptions.mithril
+      t: Un framework de JavaScript para construir aplicaciones brillantes.
+    - key: library.descriptions.inferno
+      t: 🔥 Una librería de JavaScript extremadamente rápida, al estilo de React, para construir interfaces de usuario modernas.
+    - key: library.descriptions.svelte
+      t: El framework de interfaces de usuario que mágicamente desaparece
+    - key: library.descriptions.hyperapp
+      t: Un microframework de 1Kb en JavaScript, para construir aplicaciones web declarativas.
+    - key: library.descriptions.choo
+      t: 🚂🚆 Un framework robusto de 4kb para front-end
+    - key: library.descriptions.marionette
+      t: El framework de Backbone
+    - key: library.descriptions.marko
+      t: Una amigable (¡y veloz!) librería de interfaz de usuario hecha por eBay, que hace divertido el construir aplicaciones web.
+    - key: library.descriptions.riot
+      t: Una librería de interfaz de usuario basada en componentes, simple y elegante.
+    - key: library.descriptions.dojo
+      t: 🚀 Dojo 2 - utilidades y funciones auxiliares para el lenguaje.
+    - key: library.descriptions.canjs
+      t: Un framework de JavaScript que provee administración de estados, plantillas y elementos personalizados. Ayuda a construir lo imposible mientras mantiene fáciles las cosas comunes.
+    - key: library.descriptions.glimmer_js
+      t: Una veloz y ligera librería de componentes de interfaz de usuario, creada por el equipo de Ember.js.
+    - key: library.descriptions.web_components
+      t: Una suite de polyfills que da soporte a la especificación de HTML Web Components
+    - key: library.descriptions.reagent
+      t: Una interfaz minimalista de React, para ClojureScript.
+    - key: library.descriptions.meteor
+      t: Meteor, la plataforma de aplicaciones JavaScript.
+    - key: library.descriptions.express
+      t: "Framework de aplicaciones Web para Node: minimalista, no-dogmático y veloz."
+    - key: library.descriptions.koa
+      t: "Middlewares expresivos para Node.js utilizando funciones asíncronas de ES2017."
+    - key: library.descriptions.hapi
+      t: Framework de servidor para Node.js.
+    - key: library.descriptions.feathersjs
+      t: Una capa de APIs REST y en tiempo real para aplicaciones modernas.
+    - key: library.descriptions.sails
+      t: Un framework MVC en tiempo real para Node.js.
+    - key: library.descriptions.loopback
+      t: LoopBack simplifica la construcción de aplicaciones modernas que requieren integraciones complejas.
+    - key: library.descriptions.keystone
+      t: Un framework de aplicaciones Web y gestor de contenidos para Node.js.
+    - key: library.descriptions.node_js
+      t: Motor de ejecución de JavaScript ✨🐢🚀✨
+    - key: library.descriptions.restify
+      t: El futuro de desarrollo en REST para Node.js.
+    - key: library.descriptions.adonis
+      t: Un framework de aplicaciones Web para Node.js. Hace más facil la creación de aplicaciones con menos código 😊
+    - key: library.descriptions.next_js
+      t: El framework de React
+    - key: library.descriptions.serverless
+      t: Construye aplicaciones web, mobile y IoT con arquitecturas sin servidor utilizando AWS Lambda, funciones Azure, CloudFunctions de Google ¡y más!
+    - key: library.descriptions.socket_io
+      t: Framework de aplicaciones en tiempo real para servidores Node.js.
+    - key: library.descriptions.micro
+      t: Microservicios HTTP asíncronos
+    - key: library.descriptions.kraken
+      t: Un módulo de inicialización de aplicaciones Web para Node.js, basado en Express.
+    - key: library.descriptions.redux
+      t: Un contenedor de estado predecible para aplicaciones JavaScript.
+    - key: library.descriptions.mobx
+      t: Administración de estados, simple y escalable.
+    - key: library.descriptions.graphql
+      t: GraphQL es un motor de ejecución y lenguaje de consultas, enlazable a cualquier servicio de back-end.
+    - key: library.descriptions.relay_relay_modern
+      t: Relay es un framework de JavaScript para escribir aplicaciones React controladas por datos.
+    - key: library.descriptions.falcor
+      t: Una librería de JavaScript para obtención eficiente de datos
+    - key: library.descriptions.apollo
+      t: 🚀 Un cliente completo de GraphQL, listo para producción, con soporte de caché, para todo framework de front-end y servidor de GraphQL existente.
+    - key: library.descriptions.vuex
+      t: 🗃️ Administración de estado centralizada para Vue.js.
+    - key: library.descriptions.flux
+      t: Arquitectura de aplicaciones para construir interfaces de usuario.
+    - key: library.descriptions.pouchdb
+      t: 🐨 - PouchDB es una base de datos de bolsillo.
+    - key: library.descriptions.rxjs
+      t: Extensiones reactivas para JavaScript.
+    - key: library.descriptions.realm
+      t: Realm es una base de datos mobile, una alternativa a SQLite y repositorios de datos clave-valor.
+    - key: library.descriptions.gun_js
+      t: Un motor de base de datos basado en grafos, desconectado por defecto, decentralizado y capaz de ejecutar operaciones en tiempo real.
+    - key: library.descriptions.cerebral
+      t: Administración declarativa de estados y efectos colaterales para frameworks populares de JavaScript.
+    - key: library.descriptions.ember_data
+      t: Una librería de persistencia de datos para Ember.js.
+    - key: library.descriptions.ngrx
+      t: Librerías reactivas para Angular
+    - key: library.descriptions.mongodb
+      t: Controlador nativo en NodeJS para MongoDB.
+    - key: library.descriptions.mocha
+      t: ☕️ Un framework de testing simple, flexible y divertido para Node.js y el navegador.
+    - key: library.descriptions.jasmine
+      t: Un framework de testing simple para navegadores y Node.js.
+    - key: library.descriptions.enzyme
+      t: Utilidades de testing en JavaScript para React.
+    - key: library.descriptions.jest
+      t: Testing placentero para JavaScript.
+    - key: library.descriptions.tape
+      t: Framework de testing automatizado compatible con TAP para Node.js y navegadores.
+    - key: library.descriptions.ava
+      t: 🚀 Ejecutor futurista de pruebas en JavaScript.
+    - key: library.descriptions.karma
+      t: Un espectacular ejecutor de pruebas para JavaScript.
+    - key: library.descriptions.chai
+      t: Un framework de aseveraciones en estilos BDD/TDD para Node.js y el navegador, que puede enlazarse con cualquier framework de testing.
+    - key: library.descriptions.nightwatch
+      t: Un framework en Node.js para pruebas automatizadas e integración continua, utilizando el protocolo WebDriver.
+    - key: library.descriptions.tap
+      t: Herramientas de Node para el protocolo TAP (Test Anything Protocol).
+    - key: library.descriptions.cypress
+      t: Testing confiable, fácil y rápido para cualquier cosa que funcione en un navegador.
+    - key: library.descriptions.intern
+      t: Un stack del futuro para pruebas de código en JavaScript.
+    - key: library.descriptions.phantomjs
+      t: Un navegador sin interfaz gráfica, controlable vía scripts.
+    - key: library.descriptions.nightmare
+      t: Una librería de alto nivel para automatización de navegadores.
+    - key: library.descriptions.sinon
+      t: Espías y objetos falsos para pruebas en JavaScript.
+    - key: library.descriptions.testcafe
+      t: Una herramienta en Node.js para automatizar pruebas web de punta a punta.
+    - key: library.descriptions.qunit
+      t: Un framework de testing unitario, fácil de usar.
+    - key: library.descriptions.protractor
+      t: Un framework de pruebas de punta a punta para aplicaciones en Angular.
+    - key: library.descriptions.cucumber_js
+      t: Cucumber para JavaScript.
+    - key: library.descriptions.storybook
+      t: Desarrollo y testing interactivo para componentes de interfaz de usuario de React, React Native, Vue, Angular y Ember.
+    - key: library.descriptions.sass_scss
+      t: 🌈 Enlaces de Node.js a libsass.
+    - key: library.descriptions.stylus
+      t: Un lenguaje CSS expresivo, robusto y rico en funcionalidad para Node.js.
+    - key: library.descriptions.less
+      t: Less, el lenguaje de hojas de estilos dinámicas.
+    - key: library.descriptions.bootstrap
+      t: El framework más popular de HTML/CSS/JS para crear projectos mobile-first y responsivos en la web.
+    - key: library.descriptions.foundation
+      t: El framework responsivo de front-end más avanzado del mundo. Rápidamente crea prototipos y código productivo para sitios que funcionen en cualquier clase de dispositivo.
+    - key: library.descriptions.postcss
+      t: Transformando estilos con plugins de JavaScript
+    - key: library.descriptions.bulma
+      t: Framework moderno de CSS basado en Flexbox
+    - key: library.descriptions.semantic_ui
+      t: Semantic es un framework de componentes de interfaz de usuario basado en torno a principios útiles derivados del lenguaje natural.
+    - key: library.descriptions.materialize
+      t: Materialize, un framework CSS basado en Material Design.
+    - key: library.descriptions.css_modules
+      t: Documentación acerca de módulos CSS
+    - key: library.descriptions.material_design
+      t: Componentes de Material Design en HTML, CSS y JS.
+    - key: library.descriptions.pure_css
+      t: Un sert de pequeños y responsivos módulos CSS que puedes utilizar en todos tus proyectos Web.
+    - key: library.descriptions.material_ui
+      t: Componentes de React que implementan Material Design de Google.
+    - key: library.descriptions.uikit
+      t: Un ligero y modular framework de front-end para desarrollar interfaces Web veloces y poderosas.
+    - key: library.descriptions.tachyons
+      t: CSS funcional para humanos.
+    - key: library.descriptions.skeleton
+      t: Skeleton, una plantilla base súper-simple para desarrollos preparados para mobile.
+    - key: library.descriptions.styled_components
+      t: Primitivos visuales para la era de los componentes. Utiliza las mejores partes de ES6 y CSS y estiliza tus aplicaciones sin estrés 💅
+    - key: library.descriptions.cssnext
+      t: postcss-cssnext ha sido deprecado en favor de postcss-preset-env.
+    - key: library.descriptions.webpack
+      t: Un empaquetador para JavaScript y amigos. Empaqueta múltiples módulos en unos pocos archivos. La separación de código permite cargar a demanda las distintas partes de una aplicación. A través de 'cargadores', los módulos pueden ser CommonJS, AMD, ES6, imágenes, JSON, CoffeeScript, Less, ...y lo que tú quieras.
+    - key: library.descriptions.grunt
+      t: "Grunt: el ejecutor de tareas de JavaScript"
+    - key: library.descriptions.gulp
+      t: El sistema de compilación basado en streams
+    - key: library.descriptions.browserify
+      t: require() para navegadores, al estilo de Node.js
+    - key: library.descriptions.rollup
+      t: Empaquetador moderno de módulos ES
+    - key: library.descriptions.brunch
+      t: 🍴 Herramienta de compilación para aplicaciones Web de front-end, veloz, con configuración declarativa sencilla, compilación incremental y transparente para desarrollar más rápido, un flujo de trabajo y tareas de compilación predefinido y soporte incorporado para Source Maps.
+    - key: library.descriptions.broccoli
+      t: Una librería de compilación para el navegador.
+    - key: library.descriptions.jspm
+      t: Interfaz de consola para administración de paquetes.
+    - key: library.descriptions.fusebox
+      t: Un cargador/empaquetador para JavaScript ultra-rápido, con una exhaustiva API 🔥
+    - key: library.descriptions.systemjs
+      t: Cargador dinámico de módulos ES
+    - key: library.descriptions.stealjs
+      t: Comprende JavaScript
+    - key: library.descriptions.babel
+      t: 🐠 Babel es un compilador para escribir JavaScript del futuro.
+    - key: library.descriptions.react_native
+      t: Un framework para escribir aplicaciones nativas con React.
+    - key: library.descriptions.ionic
+      t: Construye aplicaciones nativas y aplicaciones web progresivas increíbles con tecnologías web libres. Una aplicación que corre en todos lados 🎉
+    - key: library.descriptions.nativescript
+      t: NativeScript es un framework de código abierto para construir aplicaciones verdaderamente nativas con JavaScript. Utiliza habilidades Web, como Angular y Vue.js, FlexBox y CSS, y obtén performance e interfaces de usuario nativas en iOS y Android.
+    - key: library.descriptions.electron
+      t: Construye aplicaciones de escritorio multiplataforma, con JavaScript, HTML y CSS.
+    - key: library.descriptions.weex
+      t: Apache Weex
+    - key: library.descriptions.nw_js
+      t: Invoca a todos los módulos de Node.js directamente desde el DOM o un Web Worker y accede a una nueva forma de escribir aplicaciones con todas las tecnologías Web.
+    - key: library.descriptions.quasar
+      t: Quasar Framework 
+    - key: library.descriptions.expo
+      t: La plataforma Expo, para crear aplicaciones mobile multiplataforma
+    - key: library.descriptions.yarn
+      t: 📦🐈 Administración de dependencias segura, veloz y confiable.
+    - key: library.descriptions.npm
+      t: Un administrador de paquetes para JavaScript.

--- a/surveys/2018/website/src/translations/es-ES/introductions/demographics-introduction.md
+++ b/surveys/2018/website/src/translations/es-ES/introductions/demographics-introduction.md
@@ -8,4 +8,4 @@ Este año alcanzamos a 20.268 personas en 153 países diferentes. Mientras que *
 
 Por supuesto, también deberíamos mencionar que a pesar de que estamos haciendo nuestro mejor esfuerzo para que cada vez más personas se sumen a participar de la encuesta, nuestra audiencia es sólo una pequeña fracción del total de la comunidad de JavaScript, por lo cual es importante tener esto en cuenta a la hora de evaluar los resultados.
 
-Un factor que podría sin duda ayudarnos a hacer crecer nuestra audiencia, abarcando más países en el futuro, sería traducir la encuesta y sus resultados en múltiples idiomas. Si crees que puedes ayudar, por favor [háznoslo saber](https://github.com/StateOfJS/StateOfJS/issues/87)!
+Un factor que podría sin duda ayudarnos a hacer crecer nuestra audiencia, abarcando más países en el futuro, sería traducir la encuesta y sus resultados en múltiples idiomas. Si crees que puedes ayudar, por favor ¡[háznoslo saber](https://github.com/StateOfJS/StateOfJS/issues/87)!

--- a/surveys/2018/website/src/translations/es-ES/introductions/introduction.md
+++ b/surveys/2018/website/src/translations/es-ES/introductions/introduction.md
@@ -20,7 +20,7 @@ Con un espíritu de total transparencia, debemos decir que algunos de estos enla
 
 La encuesta _State of JavaScript_ fue creada y es mantenida por:
 
-- [Sacha Greif](https://twitter.com/sachagreif) (yo!): Diseño, redacción, programación
+- [Sacha Greif](https://twitter.com/sachagreif) (¡yo!): Diseño, redacción, programación
 - [Raphaël Benitte](https://twitter.com/benitteraphael): Análisis de datos, visualizaciones
 - [Michael Rambeau](https://twitter.com/michaelrambeau): Redacción, estadísticas adicionales
 

--- a/surveys/2018/website/src/translations/es-ES/introductions/introduction.md
+++ b/surveys/2018/website/src/translations/es-ES/introductions/introduction.md
@@ -36,7 +36,7 @@ Te invito a conocer mi framework de JavaScript para React/GraphQL, [Vulcan.js](h
 
 El sitio está montado sobre IBM Plex Mono. El "GIF de fuego" fue tomado prestado de [Animal Jam](https://animal-jam-roleplay.wikia.com/wiki/File:Pixel-fire-gif-1.gif). ¿Preguntas? ¿Sugerencias? ¿Quieres acceso a los datos sin procesar? [¡Ponte en contacto con nosotros!](mailto:hello@stateofjs.com)
 
-Y ahora, ¡veamos qué ha estado pasando con JavaScript este año!
+Y ahora, ¡veamos qué ha estado pasando con JavaScript en 2018!
 
 PD: Pusimos mucho esfuerzo y cariño en el sitio de este año, así que por favor ¡no andes clickeando por ahí rompiendo cosas!
 

--- a/surveys/2018/website/src/translations/es-ES/introductions/introduction.md
+++ b/surveys/2018/website/src/translations/es-ES/introductions/introduction.md
@@ -38,6 +38,6 @@ El sitio está montado sobre IBM Plex Mono. El "GIF de fuego" fue tomado prestad
 
 Y ahora, ¡veamos qué ha estado pasando con JavaScript este año!
 
-PD: Pusimos mucho esfuerzo y cariño en el stiio de este año, así que por favor no andes clickeando por ahí rompiendo cosas!
+PD: Pusimos mucho esfuerzo y cariño en el sitio de este año, así que por favor ¡no andes clickeando por ahí rompiendo cosas!
 
 <span class="conclusion__byline">– Sacha, Raphaël y Michael</span>


### PR DESCRIPTION
This PR adds support for the following:

- Homepage title is now translatable via `page.home`
- Meta description is now translatable via `meta.description`
- Country names can be translated using `countries.[country_name]`
- Gender names can be translated using `genders.[gender_name]`
- Generic source names like "E-mail" and "Others/Unkwnown" can be translated with `sources.[source_name]`
- All country maps use translatable names now
- Tool sections and tooltips show tool descriptions in the specified locale or fallback to English
- "Years" shortened version is now translated in charts

Screenshots:

![image](https://user-images.githubusercontent.com/118913/51791539-a0940b80-2183-11e9-957d-cc0855e6e08a.png)

![image](https://user-images.githubusercontent.com/118913/51791544-a8ec4680-2183-11e9-977f-f27e7acfabe6.png)

![image](https://user-images.githubusercontent.com/118913/51791548-af7abe00-2183-11e9-903a-e216852f481e.png)

![image](https://user-images.githubusercontent.com/118913/51791549-b9042600-2183-11e9-9e53-c85b928310a1.png)

![image](https://user-images.githubusercontent.com/118913/51791551-befa0700-2183-11e9-9e14-50a0bb918c20.png)

![image](https://user-images.githubusercontent.com/118913/51791557-d2a56d80-2183-11e9-9746-d098a375d168.png)
