### PR TITLE
fix(home): fix meta tags not rendering in head

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules
 
 # IDE
 .idea
+.vscode
 
 # OSX
 .DS_Store

--- a/homepages/stateofjs/src/layouts/layout.js
+++ b/homepages/stateofjs/src/layouts/layout.js
@@ -27,18 +27,18 @@ export default class Layout extends React.Component {
             { name: 'twitter:image:src', content: image },
             { name: 'twitter:title', content: title },
             { name: 'twitter:description', content: description },
-
+            // google
+            { name: 'google-site-verification', content: 'hrTRsz9fkGmQlVbLBWA4wmhn0qsI6_M3NKemTGCkpps' },
+        ]
+        const script = [
+            { src: '//js.maxmind.com/js/apis/geoip2/v2.1/geoip2.js', type: 'text/javascript' }
         ]
 
         return (
             <div
                 className={classNames('outer-wrapper', 'home-wrapper')}
             >
-                <Helmet meta={meta}>
-                    <title>{title}</title>
-                    <meta name="google-site-verification" content="hrTRsz9fkGmQlVbLBWA4wmhn0qsI6_M3NKemTGCkpps" />
-                    <script src="//js.maxmind.com/js/apis/geoip2/v2.1/geoip2.js" type="text/javascript" />
-                </Helmet>
+               <Helmet title={title} meta={meta} script={script}></Helmet>
                 <link
                     href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono:300,500"
                     rel="stylesheet"


### PR DESCRIPTION
Closes part of #209. 

Not sure if you'll actually want to merge this yet though given the social media image is still the 2018 image? Maybe I can comment out the image for now? This at least fixes the `description` and other tags being rendered now.

I couldn't get it running locally, but I copied over the changes to a test repo and it fixed it there, so hoping the same change works here too :)